### PR TITLE
Add builder script

### DIFF
--- a/builder/Containerfile
+++ b/builder/Containerfile
@@ -6,4 +6,6 @@ RUN dnf install -y cmake
 USER 1001
 # TODO: Remove the pulp-cli wheel once an image exists:
 # https://github.com/pulp/pulp-oci-images/issues/744
-RUN pip install build wheel pulp-cli
+RUN pip install build pulp-cli
+
+COPY build.sh /usr/local/bin/calunga-build

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# This script assumes the following:
+# * First argument is the name of the package to build.
+# * The directory /cachi2 exists. This contains the cachi2.env file, and all the dependencies for
+#   executing the build. This directory and its contents are generated via hermeto.
+#
+# Upon completion, the "build" directory (relative to the current directory) will contain the built
+# wheel and the source tarball.
+#
+# Why is this not included in the calunga CLI? To reduce the builder footprint, we don't want all
+# the dependencies of the calunga CLI to be installed in the builder image.
+#
+set -euo pipefail
+
+PACKAGE_NAME="$1"
+
+# This creates the PIP_FIND_LINKS environment variable.
+. /cachi2/cachi2.env
+echo "PIP_FIND_LINKS: ${PIP_FIND_LINKS}:"
+ls -la "${PIP_FIND_LINKS}"
+
+OUTPUT_DIR="$(pwd)/build"
+mkdir -p "${OUTPUT_DIR}"
+
+# Find and prepare the source tarball.
+PACKAGE_TARBALLS=$(find "${PIP_FIND_LINKS}" -name "${PACKAGE_NAME}-*.tar.gz" -printf "%f\n")
+case "$(echo "${PACKAGE_TARBALLS}" | wc -l)" in
+  0)
+    echo "Error: No tarball found for '${PACKAGE_NAME}' in ${PIP_FIND_LINKS}" >&2
+    exit 1
+    ;;
+  1)
+    PACKAGE_TARBALL="${PACKAGE_TARBALLS}"
+    ;;
+  *)
+    echo "Error: Expected exactly one tarball for '${PACKAGE_NAME}', found multiple:" >&2
+    echo "${PACKAGE_TARBALLS}" >&2
+    exit 1
+    ;;
+esac
+
+# Create a temporary directory for extraction to keep workspace clean
+TEMP_DIR=$(mktemp -d)
+cp "${PIP_FIND_LINKS}/${PACKAGE_TARBALL}" "${OUTPUT_DIR}/"
+tar -xvf "${OUTPUT_DIR}/${PACKAGE_TARBALL}" -C "${TEMP_DIR}"
+PACKAGE_DIR=$(basename "${PACKAGE_TARBALL}" .tar.gz)
+
+pushd "${TEMP_DIR}/${PACKAGE_DIR}" > /dev/null
+# Build the wheel.
+python -m build --wheel --outdir "${OUTPUT_DIR}" .
+popd > /dev/null
+
+# Make the wheel readable. When this script is executed in a Tekton Task, the output may have to be
+# read by another step within the Task that may be running as a different user/group. This ensures
+# the built wheel and source tarball are readable in all cases.
+chmod +r "${OUTPUT_DIR}"/*
+
+echo "Build output:"
+ls -la "${OUTPUT_DIR}"
+
+# Clean up temporary directory
+rm -rf "${TEMP_DIR}"


### PR DESCRIPTION
This is in preparation for starting to build OCI artifacts. The idea is that we'll use this script instead of using a Containerfile. Eventually, we'll transition over and also remove the Containerfile from the root of this repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an automated build script for creating Python package wheels and source tarballs.
  * Integrated the build script into the container image for streamlined package building.

* **Chores**
  * Ensured build outputs have appropriate permissions and visibility within multi-user environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->