### PR TITLE
Release oci artifacts

### DIFF
--- a/.tekton/build-artifact-oci-ta.yaml
+++ b/.tekton/build-artifact-oci-ta.yaml
@@ -1,0 +1,283 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: build-artifact-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: |-
+    This task allows to run a script stored on the git repository, or on the runner image, and
+    pushes arbitrary files to an OCI repository as OCI artifacts. This task is ideal for building
+    arbitrary binaries as OCI artifacts.
+  params:
+    - name: enableSymlinkCheck
+      description: |
+        Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+      type: string
+      default: "true"
+    - name: IMAGE
+      description: Reference of the OCI artifact to be produced.
+      type: string
+    - name: IMAGE_EXPIRES_AFTER
+      description: Delete image tag after specified time. Empty means to keep
+        the image tag. Time values could be something like 1h, 2d, 3w for
+        hours, days, and weeks, respectively.
+      type: string
+      default: ""
+    - name: PREFETCH_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: SCRIPT_RUNNER_IMAGE
+      description: The image to run the script in
+      type: string
+    - name: SCRIPT
+      description: The script to launch
+      type: string
+    - name: SCRIPT_WORKDIR
+      description: The directory to launch the script from
+      type: string
+      default: /var/workdir/source
+    - name: SCRIPT_ARTIFACT_RELATIVE_PATH
+      description: The relative path relative to the source directory to store on the SCRIPT_ARTIFACT
+      type: string
+      default: .
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: vfs
+    - name: HERMETIC
+      description: Determines if build will be executed without network access.
+      type: string
+      default: "false"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+  results:
+    - name: SCRIPT_RUNNER_IMAGE_REFERENCE
+      description: Reference and digest of the image used to run the script.
+      type: string
+    - name: IMAGE_DIGEST
+      description: Digest of the OCI-Artifact just built
+    - name: IMAGE_URL
+      description: OCI-Artifact repository and tag where the built OCI-Artifact was pushed
+    - name: IMAGE_REF
+      description: OCI-Artifact reference of the built OCI-Artifact
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+    - name: varlibcontainers
+      emptyDir: {}
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.PREFETCH_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+    - name: run-script
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      env:
+        - name: PARAM_ENABLE_SYMLINK_CHECK
+          value: $(params.enableSymlinkCheck)
+        - name: SCRIPT
+          value: $(params.SCRIPT)
+        - name: SCRIPT_ARTIFACT_RELATIVE_PATH
+          value: $(params.SCRIPT_ARTIFACT_RELATIVE_PATH)
+        - name: SCRIPT_WORKDIR
+          value: $(params.SCRIPT_WORKDIR)
+        - name: SCRIPT_RUNNER_IMAGE
+          value: $(params.SCRIPT_RUNNER_IMAGE)
+        - name: STORAGE_DRIVER
+          value: $(params.STORAGE_DRIVER)
+        - name: HERMETIC
+          value: $(params.HERMETIC)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Ensure the artifact directory is inside the source directory
+        REAL_ARTIFACT_PATH="$(realpath -m "/var/workdir/source/${SCRIPT_ARTIFACT_RELATIVE_PATH}")"
+        if [[ "${REAL_ARTIFACT_PATH}" != /var/workdir/source/* ]] && [[ "${REAL_ARTIFACT_PATH}" != /var/workdir/source ]]
+        then
+          echo "the trusted artifact path is out of the source directory: ${REAL_ARTIFACT_PATH}"
+          exit 1
+        fi
+
+        # Fixing group permission on /var/lib/containers
+        chown root:root /var/lib/containers
+
+        sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+        # Setting new namespace to run buildah - 2^32-2
+        echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
+
+        UNSHARE_ARGS=()
+        if [ "${HERMETIC}" == "true" ]; then
+          echo "The script will be executed with network isolation"
+          UNSHARE_ARGS+=("--net")
+        fi
+
+        HERMETO_MOUNT=""
+        HERMETO_SOURCE=""
+        if [ -d "/var/workdir/cachi2" ]; then
+          HERMETO_MOUNT="--volume /var/workdir/cachi2:/cachi2"
+          HERMETO_SOURCE=". /cachi2/cachi2.env &&"
+        fi
+
+        # Create the script file
+        printf '%s' "$SCRIPT" > /tmp/script.sh
+        chmod +x /tmp/script.sh
+
+        buildah from --name script-container "$SCRIPT_RUNNER_IMAGE"
+        BUILDAH_CMD="buildah run ${HERMETO_MOUNT} --volume /tmp/script.sh:/tmp/script.sh --volume /var/workdir/source:/var/workdir/source --workingdir ${SCRIPT_WORKDIR} --user root:root -- script-container /bin/sh -c '${HERMETO_SOURCE} exec /tmp/script.sh'"
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w /var/workdir sh -c "${BUILDAH_CMD}"
+
+        IMAGE_REFERENCE=$(buildah inspect script-container | jq -r '.FromImage')
+        # FromImage might contain the digest or not. Append the digest if it does not.
+        if [[ ! "${IMAGE_REFERENCE}" =~ "@sha256:" ]]; then
+          IMAGE_REFERENCE+="@$(buildah inspect script-container | jq -r '.FromImageDigest')"
+        fi
+        echo -n "$IMAGE_REFERENCE" > "$(results.SCRIPT_RUNNER_IMAGE_REFERENCE.path)"
+
+        # Ensure there are no symlinks going out of the artifact directory
+        check_symlinks() {
+          FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+          while read -r symlink; do
+            target=$(readlink -m "$symlink")
+            if ! [[ "$target" =~ ^$REAL_ARTIFACT_PATH ]]; then
+              echo "The script output directory contains symlink pointing outside of the directory: $symlink"
+              FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+            fi
+          done < <(find "$REAL_ARTIFACT_PATH" -type l -print)
+          if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
+            return 1
+          fi
+        }
+
+        if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
+          echo "Running symlink check"
+          check_symlinks
+        fi
+
+        # buildah requires a root owned source ta, however we don't want to run the script as root
+        # fix permissions after running the script.
+        chown -R root:root "$REAL_ARTIFACT_PATH"
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: create-oci-artifact
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        select-oci-auth "$IMAGE" > auth.json
+        AUTHFILE="$(realpath auth.json)"
+
+        [ -n "$IMAGE_EXPIRES_AFTER" ] && EXPIRE_LABEL=("--annotation" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+        # TODO: If SCRIPT_ARTIFACT_RELATIVE_PATH is a file, push that instead. Currently, it assumes,
+        # without verifying, that it may be a directory.
+
+        # Change into the artifact path so the Image Manifest contains the name of the artifact
+        # without including the build path.
+        pushd "/var/workdir/source/${SCRIPT_ARTIFACT_RELATIVE_PATH}" > /dev/null
+        ls -la .
+
+        # Use nullglob in case there are no matching files.
+        shopt -s nullglob
+        # Create an array of absolute paths for files found under the artifact path
+        ARTIFACT_FILES=(*)
+
+        echo "Pushing OCI artifact to ${IMAGE}"
+        if ! retry oras push "$IMAGE" \
+          --registry-config "${AUTHFILE}" \
+          "${EXPIRE_LABEL[@]}" \
+          "${ARTIFACT_FILES[@]}"
+        then
+          echo "Failed to push OCI artifact ${IMAGE} to registry"
+          exit 1
+        fi
+        popd > /dev/null
+
+        if ! RESULTING_DIGEST=$(retry oras resolve --registry-config "${AUTHFILE}" "${IMAGE}")
+        then
+          echo "Failed to get digest for ${IMAGE} from registry"
+          exit 1
+        fi
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" | tee "$(results.IMAGE_REF.path)"
+
+      volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.IMAGE_EXPIRES_AFTER)
+        - name: SCRIPT_ARTIFACT_RELATIVE_PATH
+          value: $(params.SCRIPT_ARTIFACT_RELATIVE_PATH)
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi

--- a/.tekton/build-artifact-oci-ta.yaml
+++ b/.tekton/build-artifact-oci-ta.yaml
@@ -241,6 +241,12 @@ spec:
         # Create an array of absolute paths for files found under the artifact path
         ARTIFACT_FILES=(*)
 
+        # Check if any files were found
+        if [ ${#ARTIFACT_FILES[@]} -eq 0 ]; then
+          echo "No files found in artifact directory"
+          exit 1
+        fi
+
         echo "Pushing OCI artifact to ${IMAGE}"
         if ! retry oras push "$IMAGE" \
           --registry-config "${AUTHFILE}" \

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -105,9 +105,9 @@ spec:
       - name: SCRIPT_RUNNER_IMAGE
         value: quay.io/lucarval/calunga-builder:latest
       - name: SCRIPT
-        value: calunga-build $(params.package-name)
+        value: "calunga-build $(params.package-name)"
       - name: HERMETIC
-        value: "true"
+        value: $(params.hermetic)
       - name: SCRIPT_ARTIFACT_RELATIVE_PATH
         value: build
     taskRef:

--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -3,11 +3,8 @@ kind: Pipeline
 metadata:
   name: build
 spec:
-  description: |
-    This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
-
-    _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
-    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+  description: >
+    Build python wheel from source.
   params:
   - description: Source Repository URL
     name: git-url
@@ -18,24 +15,6 @@ spec:
     type: string
   - description: Fully Qualified Output Image
     name: output-image
-    type: string
-  - default: .
-    description: Path to the source code of an application's component from where
-      to build image.
-    name: path-context
-    type: string
-  - default: Dockerfile
-    description: Path to the Dockerfile inside the context specified by parameter
-      path-context
-    name: dockerfile
-    type: string
-  - default: "false"
-    description: Force rebuild image
-    name: rebuild
-    type: string
-  - default: "false"
-    description: Skip checks against built image
-    name: skip-checks
     type: string
   - default: "false"
     description: Execute the build with network isolation
@@ -49,34 +28,17 @@ spec:
     description: Image tag expiration time, time values could be something like
       1h, 2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
-  - default: "false"
-    description: Build a source image.
-    name: build-source-image
     type: string
-  - default: "false"
-    description: Add built image into an OCI image index
-    name: build-image-index
-    type: string
-  - default: []
-    description: Array of --build-arg values ("arg=value" strings) for buildah
-    name: build-args
-    type: array
-  - default: ""
-    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
-    name: build-args-file
-    type: string
-  - default: "false"
-    description: Whether to enable privileged mode, should be used only with remote
-      VMs
-    name: privileged-nested
+  - description: Name of the package to build
+    name: package-name
     type: string
   results:
   - description: ""
     name: IMAGE_URL
-    value: $(tasks.build-image-index.results.IMAGE_URL)
+    value: $(tasks.build-artifact.results.IMAGE_URL)
   - description: ""
     name: IMAGE_DIGEST
-    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    value: $(tasks.build-artifact.results.IMAGE_DIGEST)
   - description: ""
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
@@ -84,23 +46,6 @@ spec:
     name: CHAINS-GIT_COMMIT
     value: $(tasks.clone-repository.results.commit)
   tasks:
-  - name: init
-    params:
-    - name: image-url
-      value: $(params.output-image)
-    - name: rebuild
-      value: $(params.rebuild)
-    - name: skip-checks
-      value: $(params.skip-checks)
-    taskRef:
-      params:
-      - name: name
-        value: init
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:1d8221c84f91b923d89de50bf16481ea729e3b68ea04a9a7cbe8485ddbb27ee6
-      - name: kind
-        value: task
-      resolver: bundles
   - name: clone-repository
     params:
     - name: url
@@ -111,8 +56,6 @@ spec:
       value: $(params.output-image).git
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
-    runAfter:
-    - init
     taskRef:
       params:
       - name: name
@@ -122,11 +65,6 @@ spec:
       - name: kind
         value: task
       resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
     workspaces:
     - name: basic-auth
       workspace: git-auth
@@ -140,8 +78,6 @@ spec:
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
-    runAfter:
-    - clone-repository
     taskRef:
       params:
       - name: name
@@ -156,380 +92,26 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
-  - name: build-container
+  - name: build-artifact
     params:
-    - name: IMAGE
-      value: $(params.output-image)
-    - name: DOCKERFILE
-      value: $(params.dockerfile)
-    - name: CONTEXT
-      value: $(params.path-context)
-    - name: HERMETIC
-      value: $(params.hermetic)
-    - name: PREFETCH_INPUT
-      value: $(params.prefetch-input)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.image-expires-after)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: BUILD_ARGS
-      value:
-      - $(params.build-args[*])
-    - name: BUILD_ARGS_FILE
-      value: $(params.build-args-file)
-    - name: PRIVILEGED_NESTED
-      value: $(params.privileged-nested)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - prefetch-dependencies
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.image-expires-after)
+      - name: IMAGE
+        value: $(params.output-image)
+      - name: PREFETCH_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: SCRIPT_RUNNER_IMAGE
+        value: quay.io/lucarval/calunga-builder:latest
+      - name: SCRIPT
+        value: calunga-build $(params.package-name)
+      - name: HERMETIC
+        value: "true"
+      - name: SCRIPT_ARTIFACT_RELATIVE_PATH
+        value: build
     taskRef:
-      params:
-      - name: name
-        value: buildah-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:06f604af4c29f08b02c36a8d9bc3dfa1606a5836fd8eeb1f6ef46048319afc38
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
-  - name: build-image-index
-    params:
-    - name: IMAGE
-      value: $(params.output-image)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.image-expires-after)
-    - name: ALWAYS_BUILD_INDEX
-      value: $(params.build-image-index)
-    - name: IMAGES
-      value:
-      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
-    runAfter:
-    - build-container
-    taskRef:
-      params:
-      - name: name
-        value: build-image-index
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:3499772af90aad0d3935629be6d37dd9292195fb629e6f43ec839c7f545a0faa
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
-  - name: build-source-image
-    params:
-    - name: BINARY_IMAGE
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: BINARY_IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: source-build-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:b1eb49583b41872b27356fee20d5f0eb6ff7f5cdeacde7ffb39655f031104728
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
-    - input: $(params.build-source-image)
-      operator: in
-      values:
-      - "true"
-  - name: deprecated-base-image-check
-    params:
-    - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: deprecated-image-check
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:3c8b81fa868e27c6266e7660a4bfb4c822846dcf4304606e71e20893b0d3e515
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: clair-scan
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: clair-scan
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:417f44117f8d87a4a62fea6589b5746612ac61640b454dbd88f74892380411f2
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: sast-snyk-check
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: sast-snyk-check-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:fe5e5ba3a72632cd505910de2eacd62c9d11ed570c325173188f8d568ac60771
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: clamav-scan
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: clamav-scan
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:7749146f7e4fe530846f1b15c9366178ec9f44776ef1922a60d3e7e2b8c6426b
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: sast-coverity-check
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: IMAGE
-      value: $(params.output-image)
-    - name: DOCKERFILE
-      value: $(params.dockerfile)
-    - name: CONTEXT
-      value: $(params.path-context)
-    - name: HERMETIC
-      value: $(params.hermetic)
-    - name: PREFETCH_INPUT
-      value: $(params.prefetch-input)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.image-expires-after)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: BUILD_ARGS
-      value:
-      - $(params.build-args[*])
-    - name: BUILD_ARGS_FILE
-      value: $(params.build-args-file)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - coverity-availability-check
-    taskRef:
-      params:
-      - name: name
-        value: sast-coverity-check-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:6b4d1321219df88d2d709f2ec1566edfd017cae58015ac8f39f92e350f9747e1
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-    - input: $(tasks.coverity-availability-check.results.STATUS)
-      operator: in
-      values:
-      - success
-  - name: coverity-availability-check
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: coverity-availability-check
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:db2b267dc15e4ed17f704ee91b8e9b38068e1a35b1018a328fdca621819d74c6
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: sast-shell-check
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: sast-shell-check-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:bf7bdde00b7212f730c1356672290af6f38d070da2c8a316987b5c32fd49e0b9
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: sast-unicode-check
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    - name: CACHI2_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: sast-unicode-check-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:a2bde66f6b4164620298c7d709b8f08515409404000fa1dc2260d2508b135651
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-  - name: apply-tags
-    params:
-    - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: apply-tags
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.2@sha256:517a51e260c0b59654a9d7b842e1ab07d76bce15ca7ce9c8fd2489a19be6463d
-      - name: kind
-        value: task
-      resolver: bundles
-  - name: push-dockerfile
-    params:
-    - name: IMAGE
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: DOCKERFILE
-      value: $(params.dockerfile)
-    - name: CONTEXT
-      value: $(params.path-context)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: push-dockerfile-oci-ta
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:8c75c4a747e635e5f3e12266a3bb6e5d3132bf54e37eaa53d505f89897dd8eca
-      - name: kind
-        value: task
-      resolver: bundles
-  - name: rpms-signature-scan
-    params:
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    runAfter:
-    - build-image-index
-    taskRef:
-      params:
-      - name: name
-        value: rpms-signature-scan
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:1b6c20ab3dbfb0972803d3ebcb2fa72642e59400c77bd66dfd82028bdd09e120
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
+      name: build-artifact-oci-ta
   workspaces:
   - name: git-auth
     optional: true

--- a/.tekton/on-pull-request.yaml.template
+++ b/.tekton/on-pull-request.yaml.template
@@ -12,7 +12,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/${name}/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ${name}
@@ -29,12 +28,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/${name}:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/${name}
-  - name: dockerfile
-    value: ${containerfile}
-  - name: build-args-file
-    value: packages/${name}/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -44,11 +37,11 @@ spec:
         "path": "./packages/${name}",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ${name}
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}

--- a/.tekton/on-pull-request.yaml.template
+++ b/.tekton/on-pull-request.yaml.template
@@ -38,7 +38,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: ${name}
+    value: ${package_name}
   pipelineRef:
     name: build
   workspaces:

--- a/.tekton/on-push.yaml.template
+++ b/.tekton/on-push.yaml.template
@@ -11,7 +11,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/${name}/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ${name}
@@ -26,12 +25,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/${name}:{{revision}}
-  - name: path-context
-    value: packages/${name}
-  - name: dockerfile
-    value: ${containerfile}
-  - name: build-args-file
-    value: packages/${name}/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -41,11 +34,11 @@ spec:
         "path": "./packages/${name}",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ${name}
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}

--- a/.tekton/on-push.yaml.template
+++ b/.tekton/on-push.yaml.template
@@ -35,7 +35,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: ${name}
+    value: ${package_name}
   pipelineRef:
     name: build
   workspaces:

--- a/.tekton/packages-on-pull-request.yaml
+++ b/.tekton/packages-on-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: absl-py
+    value: absl_py
   pipelineRef:
     name: build
   workspaces:
@@ -414,7 +414,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: annotated-types
+    value: annotated_types
   pipelineRef:
     name: build
   workspaces:
@@ -602,7 +602,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: argon2-cffi
+    value: argon2_cffi
   pipelineRef:
     name: build
   workspaces:
@@ -884,7 +884,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: async-lru
+    value: async_lru
   pipelineRef:
     name: build
   workspaces:
@@ -931,7 +931,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: async-timeout
+    value: async_timeout
   pipelineRef:
     name: build
   workspaces:
@@ -1072,7 +1072,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: aws-lambda-powertools
+    value: aws_lambda_powertools
   pipelineRef:
     name: build
   workspaces:
@@ -1213,7 +1213,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-core
+    value: azure_core
   pipelineRef:
     name: build
   workspaces:
@@ -1260,7 +1260,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-identity
+    value: azure_identity
   pipelineRef:
     name: build
   workspaces:
@@ -1307,7 +1307,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-keyvault-secrets
+    value: azure_keyvault_secrets
   pipelineRef:
     name: build
   workspaces:
@@ -1354,7 +1354,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-storage-blob
+    value: azure_storage_blob
   pipelineRef:
     name: build
   workspaces:
@@ -1401,7 +1401,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-storage-file-datalake
+    value: azure_storage_file_datalake
   pipelineRef:
     name: build
   workspaces:
@@ -1542,7 +1542,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: backports-tarfile
+    value: backports_tarfile
   pipelineRef:
     name: build
   workspaces:
@@ -2294,7 +2294,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: charset-normalizer
+    value: charset_normalizer
   pipelineRef:
     name: build
   workspaces:
@@ -2435,7 +2435,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: click-plugins
+    value: click_plugins
   pipelineRef:
     name: build
   workspaces:
@@ -2905,7 +2905,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: databricks-sdk
+    value: databricks_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -2952,7 +2952,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: databricks-sql-connector
+    value: databricks_sql_connector
   pipelineRef:
     name: build
   workspaces:
@@ -2999,7 +2999,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: dataclasses-json
+    value: dataclasses_json
   pipelineRef:
     name: build
   workspaces:
@@ -3563,7 +3563,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: docstring-parser
+    value: docstring_parser
   pipelineRef:
     name: build
   workspaces:
@@ -3845,7 +3845,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: email-validator
+    value: email_validator
   pipelineRef:
     name: build
   workspaces:
@@ -3892,7 +3892,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: et-xmlfile
+    value: et_xmlfile
   pipelineRef:
     name: build
   workspaces:
@@ -4785,7 +4785,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: gcloud-aio-auth
+    value: gcloud_aio_auth
   pipelineRef:
     name: build
   workspaces:
@@ -4832,7 +4832,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: gcloud-aio-bigquery
+    value: gcloud_aio_bigquery
   pipelineRef:
     name: build
   workspaces:
@@ -5067,7 +5067,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-ads
+    value: google_ads
   pipelineRef:
     name: build
   workspaces:
@@ -5114,7 +5114,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-api-core
+    value: google_api_core
   pipelineRef:
     name: build
   workspaces:
@@ -5161,7 +5161,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-api-python-client
+    value: google_api_python_client
   pipelineRef:
     name: build
   workspaces:
@@ -5208,7 +5208,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-auth
+    value: google_auth
   pipelineRef:
     name: build
   workspaces:
@@ -5255,7 +5255,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-auth-oauthlib
+    value: google_auth_oauthlib
   pipelineRef:
     name: build
   workspaces:
@@ -5302,7 +5302,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-aiplatform
+    value: google_cloud_aiplatform
   pipelineRef:
     name: build
   workspaces:
@@ -5349,7 +5349,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-audit-log
+    value: google_cloud_audit_log
   pipelineRef:
     name: build
   workspaces:
@@ -5396,7 +5396,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-bigquery
+    value: google_cloud_bigquery
   pipelineRef:
     name: build
   workspaces:
@@ -5443,7 +5443,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-bigquery-storage
+    value: google_cloud_bigquery_storage
   pipelineRef:
     name: build
   workspaces:
@@ -5490,7 +5490,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-bigtable
+    value: google_cloud_bigtable
   pipelineRef:
     name: build
   workspaces:
@@ -5537,7 +5537,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-dataproc
+    value: google_cloud_dataproc
   pipelineRef:
     name: build
   workspaces:
@@ -5584,7 +5584,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-logging
+    value: google_cloud_logging
   pipelineRef:
     name: build
   workspaces:
@@ -5631,7 +5631,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-pubsub
+    value: google_cloud_pubsub
   pipelineRef:
     name: build
   workspaces:
@@ -5678,7 +5678,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-resource-manager
+    value: google_cloud_resource_manager
   pipelineRef:
     name: build
   workspaces:
@@ -5725,7 +5725,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-secret-manager
+    value: google_cloud_secret_manager
   pipelineRef:
     name: build
   workspaces:
@@ -5772,7 +5772,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-storage
+    value: google_cloud_storage
   pipelineRef:
     name: build
   workspaces:
@@ -5819,7 +5819,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-vision
+    value: google_cloud_vision
   pipelineRef:
     name: build
   workspaces:
@@ -5866,7 +5866,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-crc32c
+    value: google_crc32c
   pipelineRef:
     name: build
   workspaces:
@@ -5913,7 +5913,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-resumable-media
+    value: google_resumable_media
   pipelineRef:
     name: build
   workspaces:
@@ -5960,7 +5960,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: googleapis-common-protos
+    value: googleapis_common_protos
   pipelineRef:
     name: build
   workspaces:
@@ -6007,7 +6007,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: graphql-core
+    value: graphql_core
   pipelineRef:
     name: build
   workspaces:
@@ -6148,7 +6148,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpc-google-iam-v1
+    value: grpc_google_iam_v1
   pipelineRef:
     name: build
   workspaces:
@@ -6242,7 +6242,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpcio-health-checking
+    value: grpcio_health_checking
   pipelineRef:
     name: build
   workspaces:
@@ -6289,7 +6289,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpcio-status
+    value: grpcio_status
   pipelineRef:
     name: build
   workspaces:
@@ -6336,7 +6336,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpcio-tools
+    value: grpcio_tools
   pipelineRef:
     name: build
   workspaces:
@@ -6524,7 +6524,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: hatch-fancy-pypi-readme
+    value: hatch_fancy_pypi_readme
   pipelineRef:
     name: build
   workspaces:
@@ -6571,7 +6571,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: hatch-vcs
+    value: hatch_vcs
   pipelineRef:
     name: build
   workspaces:
@@ -7229,7 +7229,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: importlib-metadata
+    value: importlib_metadata
   pipelineRef:
     name: build
   workspaces:
@@ -7276,7 +7276,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: importlib-resources
+    value: importlib_resources
   pipelineRef:
     name: build
   workspaces:
@@ -7699,7 +7699,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jaraco-context
+    value: jaraco_context
   pipelineRef:
     name: build
   workspaces:
@@ -7746,7 +7746,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jaraco-functools
+    value: jaraco_functools
   pipelineRef:
     name: build
   workspaces:
@@ -8169,7 +8169,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jupyter-client
+    value: jupyter_client
   pipelineRef:
     name: build
   workspaces:
@@ -8216,7 +8216,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jupyter-core
+    value: jupyter_core
   pipelineRef:
     name: build
   workspaces:
@@ -8451,7 +8451,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: langchain-core
+    value: langchain_core
   pipelineRef:
     name: build
   workspaces:
@@ -8545,7 +8545,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: lazy-object-proxy
+    value: lazy_object_proxy
   pipelineRef:
     name: build
   workspaces:
@@ -9015,7 +9015,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: matplotlib-inline
+    value: matplotlib_inline
   pipelineRef:
     name: build
   workspaces:
@@ -9156,7 +9156,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: meson-python
+    value: meson_python
   pipelineRef:
     name: build
   workspaces:
@@ -9203,7 +9203,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: microsoft-kiota-http
+    value: microsoft_kiota_http
   pipelineRef:
     name: build
   workspaces:
@@ -9344,7 +9344,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: more-itertools
+    value: more_itertools
   pipelineRef:
     name: build
   workspaces:
@@ -9485,7 +9485,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: msal-extensions
+    value: msal_extensions
   pipelineRef:
     name: build
   workspaces:
@@ -9720,7 +9720,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: mypy-extensions
+    value: mypy_extensions
   pipelineRef:
     name: build
   workspaces:
@@ -9814,7 +9814,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: nest-asyncio
+    value: nest_asyncio
   pipelineRef:
     name: build
   workspaces:
@@ -10237,7 +10237,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-exporter-otlp
+    value: opentelemetry_exporter_otlp
   pipelineRef:
     name: build
   workspaces:
@@ -10284,7 +10284,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-exporter-prometheus
+    value: opentelemetry_exporter_prometheus
   pipelineRef:
     name: build
   workspaces:
@@ -10331,7 +10331,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-instrumentation
+    value: opentelemetry_instrumentation
   pipelineRef:
     name: build
   workspaces:
@@ -10378,7 +10378,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-instrumentation-requests
+    value: opentelemetry_instrumentation_requests
   pipelineRef:
     name: build
   workspaces:
@@ -10425,7 +10425,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-proto
+    value: opentelemetry_proto
   pipelineRef:
     name: build
   workspaces:
@@ -10472,7 +10472,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-sdk
+    value: opentelemetry_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -10519,7 +10519,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-semantic-conventions
+    value: opentelemetry_semantic_conventions
   pipelineRef:
     name: build
   workspaces:
@@ -10566,7 +10566,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-util-http
+    value: opentelemetry_util_http
   pipelineRef:
     name: build
   workspaces:
@@ -10801,7 +10801,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pandas-gbq
+    value: pandas_gbq
   pipelineRef:
     name: build
   workspaces:
@@ -11412,7 +11412,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pkgutil-resolve-name
+    value: pkgutil_resolve_name
   pipelineRef:
     name: build
   workspaces:
@@ -11600,7 +11600,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: poetry-core
+    value: poetry_core
   pipelineRef:
     name: build
   workspaces:
@@ -11647,7 +11647,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: poetry-plugin-export
+    value: poetry_plugin_export
   pipelineRef:
     name: build
   workspaces:
@@ -11741,7 +11741,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pre-commit
+    value: pre_commit
   pipelineRef:
     name: build
   workspaces:
@@ -11788,7 +11788,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: prometheus-client
+    value: prometheus_client
   pipelineRef:
     name: build
   workspaces:
@@ -11835,7 +11835,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: prompt-toolkit
+    value: prompt_toolkit
   pipelineRef:
     name: build
   workspaces:
@@ -11929,7 +11929,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: proto-plus
+    value: proto_plus
   pipelineRef:
     name: build
   workspaces:
@@ -12117,7 +12117,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pure-eval
+    value: pure_eval
   pipelineRef:
     name: build
   workspaces:
@@ -12305,7 +12305,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyasn1-modules
+    value: pyasn1_modules
   pipelineRef:
     name: build
   workspaces:
@@ -12540,7 +12540,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pydantic-settings
+    value: pydantic_settings
   pipelineRef:
     name: build
   workspaces:
@@ -13010,7 +13010,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyproject-api
+    value: pyproject_api
   pipelineRef:
     name: build
   workspaces:
@@ -13057,7 +13057,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyproject-hooks
+    value: pyproject_hooks
   pipelineRef:
     name: build
   workspaces:
@@ -13104,7 +13104,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyproject-metadata
+    value: pyproject_metadata
   pipelineRef:
     name: build
   workspaces:
@@ -13292,7 +13292,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-asyncio
+    value: pytest_asyncio
   pipelineRef:
     name: build
   workspaces:
@@ -13339,7 +13339,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-cov
+    value: pytest_cov
   pipelineRef:
     name: build
   workspaces:
@@ -13386,7 +13386,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-mock
+    value: pytest_mock
   pipelineRef:
     name: build
   workspaces:
@@ -13433,7 +13433,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-xdist
+    value: pytest_xdist
   pipelineRef:
     name: build
   workspaces:
@@ -13527,7 +13527,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-dotenv
+    value: python_dotenv
   pipelineRef:
     name: build
   workspaces:
@@ -13574,7 +13574,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-json-logger
+    value: python_json_logger
   pipelineRef:
     name: build
   workspaces:
@@ -13621,7 +13621,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-multipart
+    value: python_multipart
   pipelineRef:
     name: build
   workspaces:
@@ -13715,7 +13715,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-telegram-bot
+    value: python_telegram_bot
   pipelineRef:
     name: build
   workspaces:
@@ -13856,7 +13856,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: readme-renderer
+    value: readme_renderer
   pipelineRef:
     name: build
   workspaces:
@@ -14044,7 +14044,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: requests-aws4auth
+    value: requests_aws4auth
   pipelineRef:
     name: build
   workspaces:
@@ -14091,7 +14091,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: requests-file
+    value: requests_file
   pipelineRef:
     name: build
   workspaces:
@@ -14232,7 +14232,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: rfc3339-validator
+    value: rfc3339_validator
   pipelineRef:
     name: build
   workspaces:
@@ -14326,7 +14326,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: rfc3986-validator
+    value: rfc3986_validator
   pipelineRef:
     name: build
   workspaces:
@@ -14420,7 +14420,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: rich-toolkit
+    value: rich_toolkit
   pipelineRef:
     name: build
   workspaces:
@@ -14655,7 +14655,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: scikit-build-core
+    value: scikit_build_core
   pipelineRef:
     name: build
   workspaces:
@@ -14843,7 +14843,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: sentry-sdk
+    value: sentry_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -14984,7 +14984,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: setuptools-scm
+    value: setuptools_scm
   pipelineRef:
     name: build
   workspaces:
@@ -15172,7 +15172,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: slack-sdk
+    value: slack_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -15219,7 +15219,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: smart-open
+    value: smart_open
   pipelineRef:
     name: build
   workspaces:
@@ -15360,7 +15360,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: snowflake-connector-python
+    value: snowflake_connector_python
   pipelineRef:
     name: build
   workspaces:
@@ -15595,7 +15595,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: sqlalchemy-bigquery
+    value: sqlalchemy_bigquery
   pipelineRef:
     name: build
   workspaces:
@@ -15642,7 +15642,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: sqlalchemy-spanner
+    value: sqlalchemy_spanner
   pipelineRef:
     name: build
   workspaces:
@@ -15783,7 +15783,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: stack-data
+    value: stack_data
   pipelineRef:
     name: build
   workspaces:
@@ -16723,7 +16723,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: trove-classifiers
+    value: trove_classifiers
   pipelineRef:
     name: build
   workspaces:
@@ -16864,7 +16864,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-protobuf
+    value: types_protobuf
   pipelineRef:
     name: build
   workspaces:
@@ -16911,7 +16911,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-psutil
+    value: types_psutil
   pipelineRef:
     name: build
   workspaces:
@@ -16958,7 +16958,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-python-dateutil
+    value: types_python_dateutil
   pipelineRef:
     name: build
   workspaces:
@@ -17005,7 +17005,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-pytz
+    value: types_pytz
   pipelineRef:
     name: build
   workspaces:
@@ -17052,7 +17052,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-pyyaml
+    value: types_pyyaml
   pipelineRef:
     name: build
   workspaces:
@@ -17099,7 +17099,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-requests
+    value: types_requests
   pipelineRef:
     name: build
   workspaces:
@@ -17146,7 +17146,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-setuptools
+    value: types_setuptools
   pipelineRef:
     name: build
   workspaces:
@@ -17193,7 +17193,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: typing-extensions
+    value: typing_extensions
   pipelineRef:
     name: build
   workspaces:
@@ -17240,7 +17240,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: typing-inspect
+    value: typing_inspect
   pipelineRef:
     name: build
   workspaces:
@@ -17287,7 +17287,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: typing-inspection
+    value: typing_inspection
   pipelineRef:
     name: build
   workspaces:
@@ -17710,7 +17710,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: weaviate-client
+    value: weaviate_client
   pipelineRef:
     name: build
   workspaces:
@@ -17851,7 +17851,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: websocket-client
+    value: websocket_client
   pipelineRef:
     name: build
   workspaces:

--- a/.tekton/packages-on-pull-request.yaml
+++ b/.tekton/packages-on-pull-request.yaml
@@ -12,7 +12,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/absl-py/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: absl-py
@@ -29,12 +28,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/absl-py:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/absl-py
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/absl-py/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -44,14 +37,14 @@ spec:
         "path": "./packages/absl-py",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: absl-py
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -66,7 +59,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/adal/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: adal
@@ -83,12 +75,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/adal:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/adal
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/adal/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -98,14 +84,14 @@ spec:
         "path": "./packages/adal",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: adal
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -120,7 +106,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiobotocore/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiobotocore
@@ -137,12 +122,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/aiobotocore:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/aiobotocore
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiobotocore/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -152,14 +131,14 @@ spec:
         "path": "./packages/aiobotocore",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiobotocore
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -174,7 +153,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiofiles/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiofiles
@@ -191,12 +169,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/aiofiles:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/aiofiles
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiofiles/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -206,14 +178,14 @@ spec:
         "path": "./packages/aiofiles",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiofiles
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -228,7 +200,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiohappyeyeballs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiohappyeyeballs
@@ -245,12 +216,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/aiohappyeyeballs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/aiohappyeyeballs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiohappyeyeballs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -260,14 +225,14 @@ spec:
         "path": "./packages/aiohappyeyeballs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiohappyeyeballs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -282,7 +247,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiohttp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiohttp
@@ -299,12 +263,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/aiohttp:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/aiohttp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiohttp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -314,14 +272,14 @@ spec:
         "path": "./packages/aiohttp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiohttp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -336,7 +294,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aioitertools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aioitertools
@@ -353,12 +310,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/aioitertools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/aioitertools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aioitertools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -368,14 +319,14 @@ spec:
         "path": "./packages/aioitertools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aioitertools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -390,7 +341,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/alembic/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: alembic
@@ -407,12 +357,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/alembic:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/alembic
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/alembic/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -422,14 +366,14 @@ spec:
         "path": "./packages/alembic",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: alembic
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -444,7 +388,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/annotated-types/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: annotated-types
@@ -461,12 +404,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/annotated-types:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/annotated-types
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/annotated-types/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -476,14 +413,14 @@ spec:
         "path": "./packages/annotated-types",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: annotated-types
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -498,7 +435,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/anyio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: anyio
@@ -515,12 +451,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/anyio:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/anyio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/anyio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -530,14 +460,14 @@ spec:
         "path": "./packages/anyio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: anyio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -552,7 +482,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/appdirs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: appdirs
@@ -569,12 +498,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/appdirs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/appdirs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/appdirs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -584,14 +507,14 @@ spec:
         "path": "./packages/appdirs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: appdirs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -606,7 +529,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/argcomplete/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: argcomplete
@@ -623,12 +545,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/argcomplete:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/argcomplete
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/argcomplete/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -638,14 +554,14 @@ spec:
         "path": "./packages/argcomplete",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: argcomplete
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -660,7 +576,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/argon2-cffi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: argon2-cffi
@@ -677,12 +592,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/argon2-cffi:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/argon2-cffi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/argon2-cffi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -692,14 +601,14 @@ spec:
         "path": "./packages/argon2-cffi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: argon2-cffi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -714,7 +623,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/arrow/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: arrow
@@ -731,12 +639,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/arrow:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/arrow
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/arrow/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -746,14 +648,14 @@ spec:
         "path": "./packages/arrow",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: arrow
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -768,7 +670,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/asgiref/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: asgiref
@@ -785,12 +686,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/asgiref:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/asgiref
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/asgiref/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -800,14 +695,14 @@ spec:
         "path": "./packages/asgiref",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: asgiref
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -822,7 +717,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/asn1crypto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: asn1crypto
@@ -839,12 +733,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/asn1crypto:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/asn1crypto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/asn1crypto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -854,14 +742,14 @@ spec:
         "path": "./packages/asn1crypto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: asn1crypto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -876,7 +764,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/astroid/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: astroid
@@ -893,12 +780,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/astroid:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/astroid
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/astroid/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -908,14 +789,14 @@ spec:
         "path": "./packages/astroid",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: astroid
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -930,7 +811,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/asttokens/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: asttokens
@@ -947,12 +827,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/asttokens:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/asttokens
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/asttokens/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -962,14 +836,14 @@ spec:
         "path": "./packages/asttokens",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: asttokens
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -984,7 +858,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/async-lru/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: async-lru
@@ -1001,12 +874,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/async-lru:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/async-lru
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/async-lru/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1016,14 +883,14 @@ spec:
         "path": "./packages/async-lru",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: async-lru
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1038,7 +905,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/async-timeout/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: async-timeout
@@ -1055,12 +921,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/async-timeout:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/async-timeout
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/async-timeout/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1070,14 +930,14 @@ spec:
         "path": "./packages/async-timeout",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: async-timeout
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1092,7 +952,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/attrs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: attrs
@@ -1109,12 +968,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/attrs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/attrs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/attrs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1124,14 +977,14 @@ spec:
         "path": "./packages/attrs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: attrs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1146,7 +999,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/authlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: authlib
@@ -1163,12 +1015,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/authlib:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/authlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/authlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1178,14 +1024,14 @@ spec:
         "path": "./packages/authlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: authlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1200,7 +1046,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aws-lambda-powertools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aws-lambda-powertools
@@ -1217,12 +1062,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/aws-lambda-powertools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/aws-lambda-powertools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aws-lambda-powertools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1232,14 +1071,14 @@ spec:
         "path": "./packages/aws-lambda-powertools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aws-lambda-powertools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1254,7 +1093,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/awscli/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: awscli
@@ -1271,12 +1109,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/awscli:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/awscli
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/awscli/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1286,14 +1118,14 @@ spec:
         "path": "./packages/awscli",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: awscli
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1308,7 +1140,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/awswrangler/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: awswrangler
@@ -1325,12 +1156,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/awswrangler:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/awswrangler
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/awswrangler/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1340,14 +1165,14 @@ spec:
         "path": "./packages/awswrangler",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: awswrangler
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1362,7 +1187,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-core
@@ -1379,12 +1203,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/azure-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1394,14 +1212,14 @@ spec:
         "path": "./packages/azure-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1416,7 +1234,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-identity/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-identity
@@ -1433,12 +1250,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-identity:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/azure-identity
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-identity/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1448,14 +1259,14 @@ spec:
         "path": "./packages/azure-identity",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-identity
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1470,7 +1281,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-keyvault-secrets/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-keyvault-secrets
@@ -1487,12 +1297,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-keyvault-secrets:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/azure-keyvault-secrets
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-keyvault-secrets/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1502,14 +1306,14 @@ spec:
         "path": "./packages/azure-keyvault-secrets",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-keyvault-secrets
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1524,7 +1328,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-storage-blob/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-storage-blob
@@ -1541,12 +1344,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-storage-blob:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/azure-storage-blob
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-storage-blob/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1556,14 +1353,14 @@ spec:
         "path": "./packages/azure-storage-blob",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-storage-blob
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1578,7 +1375,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-storage-file-datalake/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-storage-file-datalake
@@ -1595,12 +1391,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-storage-file-datalake:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/azure-storage-file-datalake
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-storage-file-datalake/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1610,14 +1400,14 @@ spec:
         "path": "./packages/azure-storage-file-datalake",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-storage-file-datalake
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1632,7 +1422,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/babel/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: babel
@@ -1649,12 +1438,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/babel:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/babel
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/babel/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1664,14 +1447,14 @@ spec:
         "path": "./packages/babel",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: babel
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1686,7 +1469,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/backoff/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: backoff
@@ -1703,12 +1485,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/backoff:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/backoff
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/backoff/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1718,14 +1494,14 @@ spec:
         "path": "./packages/backoff",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: backoff
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1740,7 +1516,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/backports-tarfile/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: backports-tarfile
@@ -1757,12 +1532,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/backports-tarfile:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/backports-tarfile
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/backports-tarfile/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1772,14 +1541,14 @@ spec:
         "path": "./packages/backports-tarfile",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: backports-tarfile
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1794,7 +1563,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/beautifulsoup4/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: beautifulsoup4
@@ -1811,12 +1579,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/beautifulsoup4:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/beautifulsoup4
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/beautifulsoup4/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1826,14 +1588,14 @@ spec:
         "path": "./packages/beautifulsoup4",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: beautifulsoup4
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1848,7 +1610,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/black/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: black
@@ -1865,12 +1626,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/black:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/black
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/black/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1880,14 +1635,14 @@ spec:
         "path": "./packages/black",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: black
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1902,7 +1657,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/bleach/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: bleach
@@ -1919,12 +1673,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/bleach:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/bleach
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/bleach/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1934,14 +1682,14 @@ spec:
         "path": "./packages/bleach",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: bleach
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1956,7 +1704,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/blinker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: blinker
@@ -1973,12 +1720,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/blinker:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/blinker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/blinker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1988,14 +1729,14 @@ spec:
         "path": "./packages/blinker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: blinker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2010,7 +1751,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/bokeh/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: bokeh
@@ -2027,12 +1767,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/bokeh:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/bokeh
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/bokeh/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2042,14 +1776,14 @@ spec:
         "path": "./packages/bokeh",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: bokeh
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2064,7 +1798,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/boto3/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: boto3
@@ -2081,12 +1814,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/boto3:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/boto3
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/boto3/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2096,14 +1823,14 @@ spec:
         "path": "./packages/boto3",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: boto3
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2118,7 +1845,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/botocore/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: botocore
@@ -2135,12 +1861,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/botocore:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/botocore
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/botocore/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2150,14 +1870,14 @@ spec:
         "path": "./packages/botocore",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: botocore
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2172,7 +1892,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/build/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: build
@@ -2189,12 +1908,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/build:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/build
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/build/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2204,14 +1917,14 @@ spec:
         "path": "./packages/build",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: build
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2226,7 +1939,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cachecontrol/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cachecontrol
@@ -2243,12 +1955,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cachecontrol:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cachecontrol
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cachecontrol/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2258,14 +1964,14 @@ spec:
         "path": "./packages/cachecontrol",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cachecontrol
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2280,7 +1986,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cachetools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cachetools
@@ -2297,12 +2002,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cachetools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cachetools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cachetools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2312,14 +2011,14 @@ spec:
         "path": "./packages/cachetools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cachetools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2334,7 +2033,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/calver/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: calver
@@ -2351,12 +2049,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/calver:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/calver
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/calver/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2366,14 +2058,14 @@ spec:
         "path": "./packages/calver",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: calver
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2388,7 +2080,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cattrs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cattrs
@@ -2405,12 +2096,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cattrs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cattrs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cattrs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2420,14 +2105,14 @@ spec:
         "path": "./packages/cattrs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cattrs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2442,7 +2127,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cffi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cffi
@@ -2459,12 +2143,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cffi:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cffi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cffi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2474,14 +2152,14 @@ spec:
         "path": "./packages/cffi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cffi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2496,7 +2174,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cfgv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cfgv
@@ -2513,12 +2190,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cfgv:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cfgv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cfgv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2528,14 +2199,14 @@ spec:
         "path": "./packages/cfgv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cfgv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2550,7 +2221,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/chardet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: chardet
@@ -2567,12 +2237,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/chardet:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/chardet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/chardet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2582,14 +2246,14 @@ spec:
         "path": "./packages/chardet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: chardet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2604,7 +2268,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/charset-normalizer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: charset-normalizer
@@ -2621,12 +2284,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/charset-normalizer:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/charset-normalizer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/charset-normalizer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2636,14 +2293,14 @@ spec:
         "path": "./packages/charset-normalizer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: charset-normalizer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2658,7 +2315,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cleo/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cleo
@@ -2675,12 +2331,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cleo:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cleo
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cleo/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2690,14 +2340,14 @@ spec:
         "path": "./packages/cleo",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cleo
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2712,7 +2362,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/click/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: click
@@ -2729,12 +2378,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/click:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/click
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/click/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2744,14 +2387,14 @@ spec:
         "path": "./packages/click",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: click
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2766,7 +2409,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/click-plugins/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: click-plugins
@@ -2783,12 +2425,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/click-plugins:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/click-plugins
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/click-plugins/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2798,14 +2434,14 @@ spec:
         "path": "./packages/click-plugins",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: click-plugins
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2820,7 +2456,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cloudpickle/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cloudpickle
@@ -2837,12 +2472,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cloudpickle:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cloudpickle
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cloudpickle/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2852,14 +2481,14 @@ spec:
         "path": "./packages/cloudpickle",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cloudpickle
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2874,7 +2503,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/colorama/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: colorama
@@ -2891,12 +2519,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/colorama:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/colorama
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/colorama/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2906,14 +2528,14 @@ spec:
         "path": "./packages/colorama",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: colorama
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2928,7 +2550,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/colorlog/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: colorlog
@@ -2945,12 +2566,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/colorlog:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/colorlog
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/colorlog/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2960,14 +2575,14 @@ spec:
         "path": "./packages/colorlog",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: colorlog
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2982,7 +2597,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/comm/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: comm
@@ -2999,12 +2613,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/comm:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/comm
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/comm/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3014,14 +2622,14 @@ spec:
         "path": "./packages/comm",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: comm
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3036,7 +2644,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/coverage/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: coverage
@@ -3053,12 +2660,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/coverage:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/coverage
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/coverage/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3068,14 +2669,14 @@ spec:
         "path": "./packages/coverage",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: coverage
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3090,7 +2691,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/crashtest/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: crashtest
@@ -3107,12 +2707,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/crashtest:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/crashtest
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/crashtest/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3122,14 +2716,14 @@ spec:
         "path": "./packages/crashtest",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: crashtest
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3144,7 +2738,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/croniter/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: croniter
@@ -3161,12 +2754,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/croniter:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/croniter
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/croniter/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3176,14 +2763,14 @@ spec:
         "path": "./packages/croniter",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: croniter
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3198,7 +2785,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cycler/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cycler
@@ -3215,12 +2801,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cycler:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cycler
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cycler/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3230,14 +2810,14 @@ spec:
         "path": "./packages/cycler",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cycler
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3252,7 +2832,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cython
@@ -3269,12 +2848,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/cython:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/cython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3284,14 +2857,14 @@ spec:
         "path": "./packages/cython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3306,7 +2879,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/databricks-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: databricks-sdk
@@ -3323,12 +2895,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/databricks-sdk:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/databricks-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/databricks-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3338,14 +2904,14 @@ spec:
         "path": "./packages/databricks-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: databricks-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3360,7 +2926,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/databricks-sql-connector/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: databricks-sql-connector
@@ -3377,12 +2942,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/databricks-sql-connector:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/databricks-sql-connector
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/databricks-sql-connector/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3392,14 +2951,14 @@ spec:
         "path": "./packages/databricks-sql-connector",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: databricks-sql-connector
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3414,7 +2973,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/dataclasses-json/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: dataclasses-json
@@ -3431,12 +2989,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/dataclasses-json:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/dataclasses-json
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/dataclasses-json/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3446,14 +2998,14 @@ spec:
         "path": "./packages/dataclasses-json",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: dataclasses-json
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3468,7 +3020,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/datadog/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: datadog
@@ -3485,12 +3036,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/datadog:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/datadog
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/datadog/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3500,14 +3045,14 @@ spec:
         "path": "./packages/datadog",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: datadog
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3522,7 +3067,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/debugpy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: debugpy
@@ -3539,12 +3083,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/debugpy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/debugpy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/debugpy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3554,14 +3092,14 @@ spec:
         "path": "./packages/debugpy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: debugpy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3576,7 +3114,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/decorator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: decorator
@@ -3593,12 +3130,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/decorator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/decorator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/decorator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3608,14 +3139,14 @@ spec:
         "path": "./packages/decorator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: decorator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3630,7 +3161,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/deepdiff/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: deepdiff
@@ -3647,12 +3177,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/deepdiff:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/deepdiff
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/deepdiff/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3662,14 +3186,14 @@ spec:
         "path": "./packages/deepdiff",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: deepdiff
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3684,7 +3208,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/defusedxml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: defusedxml
@@ -3701,12 +3224,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/defusedxml:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/defusedxml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/defusedxml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3716,14 +3233,14 @@ spec:
         "path": "./packages/defusedxml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: defusedxml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3738,7 +3255,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/deprecated/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: deprecated
@@ -3755,12 +3271,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/deprecated:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/deprecated
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/deprecated/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3770,14 +3280,14 @@ spec:
         "path": "./packages/deprecated",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: deprecated
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3792,7 +3302,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/distlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: distlib
@@ -3809,12 +3318,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/distlib:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/distlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/distlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3824,14 +3327,14 @@ spec:
         "path": "./packages/distlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: distlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3846,7 +3349,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/distro/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: distro
@@ -3863,12 +3365,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/distro:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/distro
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/distro/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3878,14 +3374,14 @@ spec:
         "path": "./packages/distro",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: distro
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3900,7 +3396,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/django/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: django
@@ -3917,12 +3412,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/django:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/django
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/django/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3932,14 +3421,14 @@ spec:
         "path": "./packages/django",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: django
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3954,7 +3443,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/dnspython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: dnspython
@@ -3971,12 +3459,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/dnspython:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/dnspython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/dnspython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3986,14 +3468,14 @@ spec:
         "path": "./packages/dnspython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: dnspython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4008,7 +3490,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/docker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: docker
@@ -4025,12 +3506,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/docker:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/docker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/docker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4040,14 +3515,14 @@ spec:
         "path": "./packages/docker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: docker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4062,7 +3537,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/docstring-parser/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: docstring-parser
@@ -4079,12 +3553,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/docstring-parser:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/docstring-parser
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/docstring-parser/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4094,14 +3562,14 @@ spec:
         "path": "./packages/docstring-parser",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: docstring-parser
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4116,7 +3584,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/docutils/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: docutils
@@ -4133,12 +3600,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/docutils:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/docutils
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/docutils/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4148,14 +3609,14 @@ spec:
         "path": "./packages/docutils",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: docutils
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4170,7 +3631,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/dulwich/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: dulwich
@@ -4187,12 +3647,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/dulwich:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/dulwich
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/dulwich/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4202,14 +3656,14 @@ spec:
         "path": "./packages/dulwich",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: dulwich
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4224,7 +3678,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/durationpy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: durationpy
@@ -4241,12 +3694,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/durationpy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/durationpy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/durationpy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4256,14 +3703,14 @@ spec:
         "path": "./packages/durationpy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: durationpy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4278,7 +3725,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/editables/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: editables
@@ -4295,12 +3741,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/editables:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/editables
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/editables/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4310,14 +3750,14 @@ spec:
         "path": "./packages/editables",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: editables
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4332,7 +3772,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/elasticsearch/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: elasticsearch
@@ -4349,12 +3788,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/elasticsearch:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/elasticsearch
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/elasticsearch/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4364,14 +3797,14 @@ spec:
         "path": "./packages/elasticsearch",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: elasticsearch
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4386,7 +3819,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/email-validator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: email-validator
@@ -4403,12 +3835,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/email-validator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/email-validator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/email-validator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4418,14 +3844,14 @@ spec:
         "path": "./packages/email-validator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: email-validator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4440,7 +3866,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/et-xmlfile/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: et-xmlfile
@@ -4457,12 +3882,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/et-xmlfile:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/et-xmlfile
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/et-xmlfile/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4472,14 +3891,14 @@ spec:
         "path": "./packages/et-xmlfile",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: et-xmlfile
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4494,7 +3913,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/eventlet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: eventlet
@@ -4511,12 +3929,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/eventlet:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/eventlet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/eventlet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4526,14 +3938,14 @@ spec:
         "path": "./packages/eventlet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: eventlet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4548,7 +3960,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/exceptiongroup/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: exceptiongroup
@@ -4565,12 +3976,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/exceptiongroup:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/exceptiongroup
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/exceptiongroup/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4580,14 +3985,14 @@ spec:
         "path": "./packages/exceptiongroup",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: exceptiongroup
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4602,7 +4007,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/execnet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: execnet
@@ -4619,12 +4023,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/execnet:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/execnet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/execnet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4634,14 +4032,14 @@ spec:
         "path": "./packages/execnet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: execnet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4656,7 +4054,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/executing/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: executing
@@ -4673,12 +4070,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/executing:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/executing
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/executing/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4688,14 +4079,14 @@ spec:
         "path": "./packages/executing",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: executing
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4710,7 +4101,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/faker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: faker
@@ -4727,12 +4117,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/faker:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/faker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/faker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4742,14 +4126,14 @@ spec:
         "path": "./packages/faker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: faker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4764,7 +4148,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fastapi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fastapi
@@ -4781,12 +4164,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/fastapi:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/fastapi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fastapi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4796,14 +4173,14 @@ spec:
         "path": "./packages/fastapi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fastapi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4818,7 +4195,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fastavro/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fastavro
@@ -4835,12 +4211,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/fastavro:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/fastavro
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fastavro/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4850,14 +4220,14 @@ spec:
         "path": "./packages/fastavro",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fastavro
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4872,7 +4242,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fastjsonschema/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fastjsonschema
@@ -4889,12 +4258,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/fastjsonschema:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/fastjsonschema
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fastjsonschema/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4904,14 +4267,14 @@ spec:
         "path": "./packages/fastjsonschema",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fastjsonschema
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4926,7 +4289,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/filelock/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: filelock
@@ -4943,12 +4305,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/filelock:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/filelock
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/filelock/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4958,14 +4314,14 @@ spec:
         "path": "./packages/filelock",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: filelock
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4980,7 +4336,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/findpython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: findpython
@@ -4997,12 +4352,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/findpython:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/findpython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/findpython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5012,14 +4361,14 @@ spec:
         "path": "./packages/findpython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: findpython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5034,7 +4383,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/flake8/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: flake8
@@ -5051,12 +4399,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/flake8:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/flake8
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/flake8/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5066,14 +4408,14 @@ spec:
         "path": "./packages/flake8",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: flake8
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5088,7 +4430,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/flatbuffers/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: flatbuffers
@@ -5105,12 +4446,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/flatbuffers:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/flatbuffers
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/flatbuffers/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5120,14 +4455,14 @@ spec:
         "path": "./packages/flatbuffers",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: flatbuffers
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5142,7 +4477,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fonttools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fonttools
@@ -5159,12 +4493,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/fonttools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/fonttools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fonttools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5174,14 +4502,14 @@ spec:
         "path": "./packages/fonttools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fonttools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5196,7 +4524,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fqdn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fqdn
@@ -5213,12 +4540,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/fqdn:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/fqdn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fqdn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5228,14 +4549,14 @@ spec:
         "path": "./packages/fqdn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fqdn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5250,7 +4571,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/freezegun/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: freezegun
@@ -5267,12 +4587,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/freezegun:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/freezegun
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/freezegun/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5282,14 +4596,14 @@ spec:
         "path": "./packages/freezegun",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: freezegun
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5304,7 +4618,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/frozenlist/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: frozenlist
@@ -5321,12 +4634,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/frozenlist:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/frozenlist
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/frozenlist/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5336,14 +4643,14 @@ spec:
         "path": "./packages/frozenlist",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: frozenlist
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5358,7 +4665,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fsspec/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fsspec
@@ -5375,12 +4681,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/fsspec:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/fsspec
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fsspec/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5390,14 +4690,14 @@ spec:
         "path": "./packages/fsspec",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fsspec
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5412,7 +4712,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/future/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: future
@@ -5429,12 +4728,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/future:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/future
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/future/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5444,14 +4737,14 @@ spec:
         "path": "./packages/future",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: future
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5466,7 +4759,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gcloud-aio-auth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gcloud-aio-auth
@@ -5483,12 +4775,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gcloud-aio-auth:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gcloud-aio-auth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gcloud-aio-auth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5498,14 +4784,14 @@ spec:
         "path": "./packages/gcloud-aio-auth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gcloud-aio-auth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5520,7 +4806,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gcloud-aio-bigquery/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gcloud-aio-bigquery
@@ -5537,12 +4822,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gcloud-aio-bigquery:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gcloud-aio-bigquery
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gcloud-aio-bigquery/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5552,14 +4831,14 @@ spec:
         "path": "./packages/gcloud-aio-bigquery",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gcloud-aio-bigquery
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5574,7 +4853,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gcsfs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gcsfs
@@ -5591,12 +4869,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gcsfs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gcsfs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gcsfs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5606,14 +4878,14 @@ spec:
         "path": "./packages/gcsfs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gcsfs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5628,7 +4900,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gevent/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gevent
@@ -5645,12 +4916,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gevent:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gevent
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gevent/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5660,14 +4925,14 @@ spec:
         "path": "./packages/gevent",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gevent
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5682,7 +4947,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gitdb/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gitdb
@@ -5699,12 +4963,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gitdb:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gitdb
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gitdb/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5714,14 +4972,14 @@ spec:
         "path": "./packages/gitdb",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gitdb
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5736,7 +4994,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gitpython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gitpython
@@ -5753,12 +5010,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gitpython:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gitpython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gitpython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5768,14 +5019,14 @@ spec:
         "path": "./packages/gitpython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gitpython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5790,7 +5041,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-ads/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-ads
@@ -5807,12 +5057,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-ads:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-ads
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-ads/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5822,14 +5066,14 @@ spec:
         "path": "./packages/google-ads",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-ads
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5844,7 +5088,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-api-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-api-core
@@ -5861,12 +5104,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-api-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-api-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-api-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5876,14 +5113,14 @@ spec:
         "path": "./packages/google-api-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-api-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5898,7 +5135,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-api-python-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-api-python-client
@@ -5915,12 +5151,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-api-python-client:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-api-python-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-api-python-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5930,14 +5160,14 @@ spec:
         "path": "./packages/google-api-python-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-api-python-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5952,7 +5182,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-auth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-auth
@@ -5969,12 +5198,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-auth:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-auth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-auth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5984,14 +5207,14 @@ spec:
         "path": "./packages/google-auth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-auth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6006,7 +5229,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-auth-oauthlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-auth-oauthlib
@@ -6023,12 +5245,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-auth-oauthlib:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-auth-oauthlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-auth-oauthlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6038,14 +5254,14 @@ spec:
         "path": "./packages/google-auth-oauthlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-auth-oauthlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6060,7 +5276,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-aiplatform/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-aiplatform
@@ -6077,12 +5292,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-aiplatform:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-aiplatform
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-aiplatform/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6092,14 +5301,14 @@ spec:
         "path": "./packages/google-cloud-aiplatform",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-aiplatform
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6114,7 +5323,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-audit-log/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-audit-log
@@ -6131,12 +5339,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-audit-log:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-audit-log
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-audit-log/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6146,14 +5348,14 @@ spec:
         "path": "./packages/google-cloud-audit-log",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-audit-log
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6168,7 +5370,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-bigquery/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-bigquery
@@ -6185,12 +5386,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-bigquery:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-bigquery
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-bigquery/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6200,14 +5395,14 @@ spec:
         "path": "./packages/google-cloud-bigquery",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-bigquery
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6222,7 +5417,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-bigquery-storage/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-bigquery-storage
@@ -6239,12 +5433,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-bigquery-storage:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-bigquery-storage
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-bigquery-storage/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6254,14 +5442,14 @@ spec:
         "path": "./packages/google-cloud-bigquery-storage",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-bigquery-storage
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6276,7 +5464,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-bigtable/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-bigtable
@@ -6293,12 +5480,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-bigtable:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-bigtable
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-bigtable/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6308,14 +5489,14 @@ spec:
         "path": "./packages/google-cloud-bigtable",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-bigtable
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6330,7 +5511,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-dataproc/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-dataproc
@@ -6347,12 +5527,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-dataproc:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-dataproc
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-dataproc/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6362,14 +5536,14 @@ spec:
         "path": "./packages/google-cloud-dataproc",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-dataproc
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6384,7 +5558,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-logging/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-logging
@@ -6401,12 +5574,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-logging:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-logging
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-logging/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6416,14 +5583,14 @@ spec:
         "path": "./packages/google-cloud-logging",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-logging
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6438,7 +5605,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-pubsub/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-pubsub
@@ -6455,12 +5621,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-pubsub:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-pubsub
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-pubsub/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6470,14 +5630,14 @@ spec:
         "path": "./packages/google-cloud-pubsub",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-pubsub
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6492,7 +5652,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-resource-manager/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-resource-manager
@@ -6509,12 +5668,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-resource-manager:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-resource-manager
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-resource-manager/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6524,14 +5677,14 @@ spec:
         "path": "./packages/google-cloud-resource-manager",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-resource-manager
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6546,7 +5699,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-secret-manager/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-secret-manager
@@ -6563,12 +5715,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-secret-manager:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-secret-manager
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-secret-manager/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6578,14 +5724,14 @@ spec:
         "path": "./packages/google-cloud-secret-manager",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-secret-manager
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6600,7 +5746,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-storage/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-storage
@@ -6617,12 +5762,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-storage:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-storage
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-storage/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6632,14 +5771,14 @@ spec:
         "path": "./packages/google-cloud-storage",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-storage
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6654,7 +5793,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-vision/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-vision
@@ -6671,12 +5809,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-vision:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-cloud-vision
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-vision/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6686,14 +5818,14 @@ spec:
         "path": "./packages/google-cloud-vision",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-vision
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6708,7 +5840,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-crc32c/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-crc32c
@@ -6725,12 +5856,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-crc32c:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-crc32c
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-crc32c/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6740,14 +5865,14 @@ spec:
         "path": "./packages/google-crc32c",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-crc32c
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6762,7 +5887,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-resumable-media/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-resumable-media
@@ -6779,12 +5903,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/google-resumable-media:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/google-resumable-media
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-resumable-media/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6794,14 +5912,14 @@ spec:
         "path": "./packages/google-resumable-media",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-resumable-media
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6816,7 +5934,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/googleapis-common-protos/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: googleapis-common-protos
@@ -6833,12 +5950,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/googleapis-common-protos:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/googleapis-common-protos
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/googleapis-common-protos/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6848,14 +5959,14 @@ spec:
         "path": "./packages/googleapis-common-protos",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: googleapis-common-protos
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6870,7 +5981,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/graphql-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: graphql-core
@@ -6887,12 +5997,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/graphql-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/graphql-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/graphql-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6902,14 +6006,14 @@ spec:
         "path": "./packages/graphql-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: graphql-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6924,7 +6028,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/graphviz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: graphviz
@@ -6941,12 +6044,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/graphviz:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/graphviz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/graphviz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6956,14 +6053,14 @@ spec:
         "path": "./packages/graphviz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: graphviz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6978,7 +6075,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/greenlet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: greenlet
@@ -6995,12 +6091,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/greenlet:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/greenlet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/greenlet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7010,14 +6100,14 @@ spec:
         "path": "./packages/greenlet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: greenlet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7032,7 +6122,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpc-google-iam-v1/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpc-google-iam-v1
@@ -7049,12 +6138,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/grpc-google-iam-v1:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/grpc-google-iam-v1
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpc-google-iam-v1/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7064,14 +6147,14 @@ spec:
         "path": "./packages/grpc-google-iam-v1",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpc-google-iam-v1
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7086,7 +6169,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio
@@ -7103,12 +6185,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/grpcio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7118,14 +6194,14 @@ spec:
         "path": "./packages/grpcio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7140,7 +6216,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio-health-checking/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio-health-checking
@@ -7157,12 +6232,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio-health-checking:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/grpcio-health-checking
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio-health-checking/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7172,14 +6241,14 @@ spec:
         "path": "./packages/grpcio-health-checking",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio-health-checking
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7194,7 +6263,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio-status/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio-status
@@ -7211,12 +6279,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio-status:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/grpcio-status
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio-status/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7226,14 +6288,14 @@ spec:
         "path": "./packages/grpcio-status",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio-status
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7248,7 +6310,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio-tools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio-tools
@@ -7265,12 +6326,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio-tools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/grpcio-tools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio-tools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7280,14 +6335,14 @@ spec:
         "path": "./packages/grpcio-tools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio-tools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7302,7 +6357,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gunicorn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gunicorn
@@ -7319,12 +6373,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/gunicorn:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/gunicorn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gunicorn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7334,14 +6382,14 @@ spec:
         "path": "./packages/gunicorn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gunicorn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7356,7 +6404,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/h11/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: h11
@@ -7373,12 +6420,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/h11:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/h11
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/h11/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7388,14 +6429,14 @@ spec:
         "path": "./packages/h11",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: h11
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7410,7 +6451,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/h2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: h2
@@ -7427,12 +6467,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/h2:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/h2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/h2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7442,14 +6476,14 @@ spec:
         "path": "./packages/h2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: h2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7464,7 +6498,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hatch-fancy-pypi-readme/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hatch-fancy-pypi-readme
@@ -7481,12 +6514,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/hatch-fancy-pypi-readme:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/hatch-fancy-pypi-readme
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hatch-fancy-pypi-readme/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7496,14 +6523,14 @@ spec:
         "path": "./packages/hatch-fancy-pypi-readme",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hatch-fancy-pypi-readme
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7518,7 +6545,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hatch-vcs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hatch-vcs
@@ -7535,12 +6561,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/hatch-vcs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/hatch-vcs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hatch-vcs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7550,14 +6570,14 @@ spec:
         "path": "./packages/hatch-vcs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hatch-vcs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7572,7 +6592,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hatchling/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hatchling
@@ -7589,12 +6608,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/hatchling:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/hatchling
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hatchling/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7604,14 +6617,14 @@ spec:
         "path": "./packages/hatchling",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hatchling
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7626,7 +6639,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hpack/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hpack
@@ -7643,12 +6655,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/hpack:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/hpack
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hpack/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7658,14 +6664,14 @@ spec:
         "path": "./packages/hpack",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hpack
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7680,7 +6686,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httpcore/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httpcore
@@ -7697,12 +6702,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/httpcore:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/httpcore
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httpcore/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7712,14 +6711,14 @@ spec:
         "path": "./packages/httpcore",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httpcore
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7734,7 +6733,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httplib2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httplib2
@@ -7751,12 +6749,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/httplib2:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/httplib2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httplib2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7766,14 +6758,14 @@ spec:
         "path": "./packages/httplib2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httplib2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7788,7 +6780,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httptools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httptools
@@ -7805,12 +6796,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/httptools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/httptools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httptools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7820,14 +6805,14 @@ spec:
         "path": "./packages/httptools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httptools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7842,7 +6827,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httpx/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httpx
@@ -7859,12 +6843,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/httpx:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/httpx
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httpx/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7874,14 +6852,14 @@ spec:
         "path": "./packages/httpx",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httpx
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7896,7 +6874,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/humanfriendly/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: humanfriendly
@@ -7913,12 +6890,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/humanfriendly:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/humanfriendly
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/humanfriendly/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7928,14 +6899,14 @@ spec:
         "path": "./packages/humanfriendly",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: humanfriendly
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7950,7 +6921,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/humanize/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: humanize
@@ -7967,12 +6937,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/humanize:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/humanize
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/humanize/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7982,14 +6946,14 @@ spec:
         "path": "./packages/humanize",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: humanize
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8004,7 +6968,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hvac/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hvac
@@ -8021,12 +6984,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/hvac:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/hvac
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hvac/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8036,14 +6993,14 @@ spec:
         "path": "./packages/hvac",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hvac
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8058,7 +7015,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hyperframe/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hyperframe
@@ -8075,12 +7031,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/hyperframe:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/hyperframe
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hyperframe/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8090,14 +7040,14 @@ spec:
         "path": "./packages/hyperframe",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hyperframe
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8112,7 +7062,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/identify/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: identify
@@ -8129,12 +7078,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/identify:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/identify
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/identify/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8144,14 +7087,14 @@ spec:
         "path": "./packages/identify",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: identify
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8166,7 +7109,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/idna/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: idna
@@ -8183,12 +7125,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/idna:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/idna
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/idna/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8198,14 +7134,14 @@ spec:
         "path": "./packages/idna",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: idna
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8220,7 +7156,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/imageio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: imageio
@@ -8237,12 +7172,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/imageio:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/imageio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/imageio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8252,14 +7181,14 @@ spec:
         "path": "./packages/imageio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: imageio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8274,7 +7203,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/importlib-metadata/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: importlib-metadata
@@ -8291,12 +7219,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/importlib-metadata:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/importlib-metadata
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/importlib-metadata/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8306,14 +7228,14 @@ spec:
         "path": "./packages/importlib-metadata",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: importlib-metadata
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8328,7 +7250,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/importlib-resources/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: importlib-resources
@@ -8345,12 +7266,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/importlib-resources:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/importlib-resources
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/importlib-resources/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8360,14 +7275,14 @@ spec:
         "path": "./packages/importlib-resources",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: importlib-resources
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8382,7 +7297,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/inflection/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: inflection
@@ -8399,12 +7313,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/inflection:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/inflection
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/inflection/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8414,14 +7322,14 @@ spec:
         "path": "./packages/inflection",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: inflection
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8436,7 +7344,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/iniconfig/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: iniconfig
@@ -8453,12 +7360,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/iniconfig:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/iniconfig
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/iniconfig/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8468,14 +7369,14 @@ spec:
         "path": "./packages/iniconfig",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: iniconfig
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8490,7 +7391,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/installer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: installer
@@ -8507,12 +7407,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/installer:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/installer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/installer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8522,14 +7416,14 @@ spec:
         "path": "./packages/installer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: installer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8544,7 +7438,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ipython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ipython
@@ -8561,12 +7454,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/ipython:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/ipython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ipython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8576,14 +7463,14 @@ spec:
         "path": "./packages/ipython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ipython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8598,7 +7485,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/isodate/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: isodate
@@ -8615,12 +7501,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/isodate:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/isodate
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/isodate/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8630,14 +7510,14 @@ spec:
         "path": "./packages/isodate",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: isodate
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8652,7 +7532,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/isoduration/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: isoduration
@@ -8669,12 +7548,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/isoduration:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/isoduration
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/isoduration/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8684,14 +7557,14 @@ spec:
         "path": "./packages/isoduration",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: isoduration
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8706,7 +7579,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/isort/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: isort
@@ -8723,12 +7595,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/isort:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/isort
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/isort/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8738,14 +7604,14 @@ spec:
         "path": "./packages/isort",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: isort
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8760,7 +7626,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/itsdangerous/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: itsdangerous
@@ -8777,12 +7642,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/itsdangerous:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/itsdangerous
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/itsdangerous/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8792,14 +7651,14 @@ spec:
         "path": "./packages/itsdangerous",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: itsdangerous
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8814,7 +7673,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jaraco-context/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jaraco-context
@@ -8831,12 +7689,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jaraco-context:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jaraco-context
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jaraco-context/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8846,14 +7698,14 @@ spec:
         "path": "./packages/jaraco-context",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jaraco-context
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8868,7 +7720,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jaraco-functools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jaraco-functools
@@ -8885,12 +7736,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jaraco-functools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jaraco-functools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jaraco-functools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8900,14 +7745,14 @@ spec:
         "path": "./packages/jaraco-functools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jaraco-functools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8922,7 +7767,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jedi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jedi
@@ -8939,12 +7783,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jedi:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jedi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jedi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8954,14 +7792,14 @@ spec:
         "path": "./packages/jedi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jedi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8976,7 +7814,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jeepney/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jeepney
@@ -8993,12 +7830,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jeepney:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jeepney
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jeepney/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9008,14 +7839,14 @@ spec:
         "path": "./packages/jeepney",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jeepney
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9030,7 +7861,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jinja2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jinja2
@@ -9047,12 +7877,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jinja2:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jinja2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jinja2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9062,14 +7886,14 @@ spec:
         "path": "./packages/jinja2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jinja2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9084,7 +7908,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jmespath/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jmespath
@@ -9101,12 +7924,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jmespath:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jmespath
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jmespath/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9116,14 +7933,14 @@ spec:
         "path": "./packages/jmespath",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jmespath
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9138,7 +7955,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/joblib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: joblib
@@ -9155,12 +7971,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/joblib:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/joblib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/joblib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9170,14 +7980,14 @@ spec:
         "path": "./packages/joblib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: joblib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9192,7 +8002,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/json5/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: json5
@@ -9209,12 +8018,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/json5:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/json5
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/json5/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9224,14 +8027,14 @@ spec:
         "path": "./packages/json5",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: json5
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9246,7 +8049,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jsonpatch/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jsonpatch
@@ -9263,12 +8065,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jsonpatch:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jsonpatch
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jsonpatch/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9278,14 +8074,14 @@ spec:
         "path": "./packages/jsonpatch",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jsonpatch
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9300,7 +8096,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jsonpointer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jsonpointer
@@ -9317,12 +8112,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jsonpointer:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jsonpointer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jsonpointer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9332,14 +8121,14 @@ spec:
         "path": "./packages/jsonpointer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jsonpointer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9354,7 +8143,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jupyter-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jupyter-client
@@ -9371,12 +8159,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jupyter-client:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jupyter-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jupyter-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9386,14 +8168,14 @@ spec:
         "path": "./packages/jupyter-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jupyter-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9408,7 +8190,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jupyter-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jupyter-core
@@ -9425,12 +8206,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/jupyter-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/jupyter-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jupyter-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9440,14 +8215,14 @@ spec:
         "path": "./packages/jupyter-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jupyter-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9462,7 +8237,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/keras/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: keras
@@ -9479,12 +8253,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/keras:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/keras
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/keras/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9494,14 +8262,14 @@ spec:
         "path": "./packages/keras",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: keras
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9516,7 +8284,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/keyring/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: keyring
@@ -9533,12 +8300,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/keyring:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/keyring
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/keyring/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9548,14 +8309,14 @@ spec:
         "path": "./packages/keyring",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: keyring
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9570,7 +8331,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/kiwisolver/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: kiwisolver
@@ -9587,12 +8347,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/kiwisolver:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/kiwisolver
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/kiwisolver/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9602,14 +8356,14 @@ spec:
         "path": "./packages/kiwisolver",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: kiwisolver
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9624,7 +8378,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/langchain/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: langchain
@@ -9641,12 +8394,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/langchain:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/langchain
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/langchain/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9656,14 +8403,14 @@ spec:
         "path": "./packages/langchain",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: langchain
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9678,7 +8425,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/langchain-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: langchain-core
@@ -9695,12 +8441,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/langchain-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/langchain-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/langchain-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9710,14 +8450,14 @@ spec:
         "path": "./packages/langchain-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: langchain-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9732,7 +8472,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/langsmith/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: langsmith
@@ -9749,12 +8488,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/langsmith:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/langsmith
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/langsmith/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9764,14 +8497,14 @@ spec:
         "path": "./packages/langsmith",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: langsmith
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9786,7 +8519,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/lazy-object-proxy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: lazy-object-proxy
@@ -9803,12 +8535,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/lazy-object-proxy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/lazy-object-proxy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/lazy-object-proxy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9818,14 +8544,14 @@ spec:
         "path": "./packages/lazy-object-proxy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: lazy-object-proxy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9840,7 +8566,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/limits/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: limits
@@ -9857,12 +8582,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/limits:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/limits
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/limits/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9872,14 +8591,14 @@ spec:
         "path": "./packages/limits",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: limits
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9894,7 +8613,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/loguru/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: loguru
@@ -9911,12 +8629,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/loguru:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/loguru
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/loguru/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9926,14 +8638,14 @@ spec:
         "path": "./packages/loguru",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: loguru
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9948,7 +8660,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/lxml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: lxml
@@ -9965,12 +8676,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/lxml:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/lxml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/lxml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9980,14 +8685,14 @@ spec:
         "path": "./packages/lxml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: lxml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10002,7 +8707,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/lz4/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: lz4
@@ -10019,12 +8723,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/lz4:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/lz4
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/lz4/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10034,14 +8732,14 @@ spec:
         "path": "./packages/lz4",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: lz4
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10056,7 +8754,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mako/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mako
@@ -10073,12 +8770,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mako:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mako
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mako/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10088,14 +8779,14 @@ spec:
         "path": "./packages/mako",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mako
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10110,7 +8801,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/markdown/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: markdown
@@ -10127,12 +8817,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/markdown:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/markdown
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/markdown/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10142,14 +8826,14 @@ spec:
         "path": "./packages/markdown",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: markdown
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10164,7 +8848,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/markdown-it-py/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: markdown-it-py
@@ -10181,12 +8864,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/markdown-it-py:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/markdown-it-py
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/markdown-it-py/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10196,14 +8873,14 @@ spec:
         "path": "./packages/markdown-it-py",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: markdown-it-py
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10218,7 +8895,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/markupsafe/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: markupsafe
@@ -10235,12 +8911,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/markupsafe:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/markupsafe
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/markupsafe/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10250,14 +8920,14 @@ spec:
         "path": "./packages/markupsafe",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: markupsafe
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10272,7 +8942,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/marshmallow/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: marshmallow
@@ -10289,12 +8958,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/marshmallow:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/marshmallow
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/marshmallow/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10304,14 +8967,14 @@ spec:
         "path": "./packages/marshmallow",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: marshmallow
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10326,7 +8989,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/matplotlib-inline/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: matplotlib-inline
@@ -10343,12 +9005,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/matplotlib-inline:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/matplotlib-inline
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/matplotlib-inline/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10358,14 +9014,14 @@ spec:
         "path": "./packages/matplotlib-inline",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: matplotlib-inline
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10380,7 +9036,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mccabe/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mccabe
@@ -10397,12 +9052,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mccabe:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mccabe
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mccabe/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10412,14 +9061,14 @@ spec:
         "path": "./packages/mccabe",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mccabe
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10434,7 +9083,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mdurl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mdurl
@@ -10451,12 +9099,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mdurl:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mdurl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mdurl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10466,14 +9108,14 @@ spec:
         "path": "./packages/mdurl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mdurl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10488,7 +9130,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/meson-python/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: meson-python
@@ -10505,12 +9146,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/meson-python:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/meson-python
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/meson-python/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10520,14 +9155,14 @@ spec:
         "path": "./packages/meson-python",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: meson-python
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10542,7 +9177,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/microsoft-kiota-http/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: microsoft-kiota-http
@@ -10559,12 +9193,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/microsoft-kiota-http:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/microsoft-kiota-http
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/microsoft-kiota-http/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10574,14 +9202,14 @@ spec:
         "path": "./packages/microsoft-kiota-http",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: microsoft-kiota-http
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10596,7 +9224,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mistune/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mistune
@@ -10613,12 +9240,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mistune:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mistune
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mistune/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10628,14 +9249,14 @@ spec:
         "path": "./packages/mistune",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mistune
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10650,7 +9271,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mock/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mock
@@ -10667,12 +9287,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mock:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mock
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mock/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10682,14 +9296,14 @@ spec:
         "path": "./packages/mock",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mock
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10704,7 +9318,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/more-itertools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: more-itertools
@@ -10721,12 +9334,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/more-itertools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/more-itertools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/more-itertools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10736,14 +9343,14 @@ spec:
         "path": "./packages/more-itertools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: more-itertools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10758,7 +9365,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mpmath/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mpmath
@@ -10775,12 +9381,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mpmath:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mpmath
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mpmath/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10790,14 +9390,14 @@ spec:
         "path": "./packages/mpmath",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mpmath
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10812,7 +9412,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/msal/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: msal
@@ -10829,12 +9428,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/msal:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/msal
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/msal/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10844,14 +9437,14 @@ spec:
         "path": "./packages/msal",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: msal
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10866,7 +9459,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/msal-extensions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: msal-extensions
@@ -10883,12 +9475,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/msal-extensions:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/msal-extensions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/msal-extensions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10898,14 +9484,14 @@ spec:
         "path": "./packages/msal-extensions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: msal-extensions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10920,7 +9506,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/msgpack/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: msgpack
@@ -10937,12 +9522,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/msgpack:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/msgpack
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/msgpack/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10952,14 +9531,14 @@ spec:
         "path": "./packages/msgpack",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: msgpack
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10974,7 +9553,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/multidict/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: multidict
@@ -10991,12 +9569,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/multidict:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/multidict
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/multidict/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11006,14 +9578,14 @@ spec:
         "path": "./packages/multidict",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: multidict
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11028,7 +9600,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/multiprocess/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: multiprocess
@@ -11045,12 +9616,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/multiprocess:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/multiprocess
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/multiprocess/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11060,14 +9625,14 @@ spec:
         "path": "./packages/multiprocess",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: multiprocess
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11082,7 +9647,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mypy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mypy
@@ -11099,12 +9663,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mypy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mypy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mypy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11114,14 +9672,14 @@ spec:
         "path": "./packages/mypy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mypy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11136,7 +9694,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mypy-extensions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mypy-extensions
@@ -11153,12 +9710,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/mypy-extensions:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/mypy-extensions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mypy-extensions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11168,14 +9719,14 @@ spec:
         "path": "./packages/mypy-extensions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mypy-extensions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11190,7 +9741,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/narwhals/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: narwhals
@@ -11207,12 +9757,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/narwhals:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/narwhals
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/narwhals/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11222,14 +9766,14 @@ spec:
         "path": "./packages/narwhals",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: narwhals
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11244,7 +9788,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/nest-asyncio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: nest-asyncio
@@ -11261,12 +9804,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/nest-asyncio:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/nest-asyncio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/nest-asyncio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11276,14 +9813,14 @@ spec:
         "path": "./packages/nest-asyncio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: nest-asyncio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11298,7 +9835,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/networkx/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: networkx
@@ -11315,12 +9851,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/networkx:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/networkx
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/networkx/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11330,14 +9860,14 @@ spec:
         "path": "./packages/networkx",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: networkx
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11352,7 +9882,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ninja/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ninja
@@ -11369,12 +9898,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/ninja:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/ninja
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ninja/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11384,14 +9907,14 @@ spec:
         "path": "./packages/ninja",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ninja
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11406,7 +9929,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/nltk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: nltk
@@ -11423,12 +9945,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/nltk:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/nltk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/nltk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11438,14 +9954,14 @@ spec:
         "path": "./packages/nltk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: nltk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11460,7 +9976,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/nodeenv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: nodeenv
@@ -11477,12 +9992,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/nodeenv:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/nodeenv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/nodeenv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11492,14 +10001,14 @@ spec:
         "path": "./packages/nodeenv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: nodeenv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11514,7 +10023,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/numpy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: numpy
@@ -11531,12 +10039,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/numpy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/numpy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/numpy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11546,14 +10048,14 @@ spec:
         "path": "./packages/numpy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: numpy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11568,7 +10070,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/oauth2client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: oauth2client
@@ -11585,12 +10086,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/oauth2client:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/oauth2client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/oauth2client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11600,14 +10095,14 @@ spec:
         "path": "./packages/oauth2client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: oauth2client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11622,7 +10117,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/oauthlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: oauthlib
@@ -11639,12 +10133,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/oauthlib:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/oauthlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/oauthlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11654,14 +10142,14 @@ spec:
         "path": "./packages/oauthlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: oauthlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11676,7 +10164,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/openpyxl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: openpyxl
@@ -11693,12 +10180,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/openpyxl:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/openpyxl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/openpyxl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11708,14 +10189,14 @@ spec:
         "path": "./packages/openpyxl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: openpyxl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11730,7 +10211,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-exporter-otlp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-exporter-otlp
@@ -11747,12 +10227,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-exporter-otlp:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-exporter-otlp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-exporter-otlp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11762,14 +10236,14 @@ spec:
         "path": "./packages/opentelemetry-exporter-otlp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-exporter-otlp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11784,7 +10258,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-exporter-prometheus/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-exporter-prometheus
@@ -11801,12 +10274,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-exporter-prometheus:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-exporter-prometheus
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-exporter-prometheus/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11816,14 +10283,14 @@ spec:
         "path": "./packages/opentelemetry-exporter-prometheus",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-exporter-prometheus
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11838,7 +10305,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-instrumentation/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-instrumentation
@@ -11855,12 +10321,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-instrumentation:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-instrumentation
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-instrumentation/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11870,14 +10330,14 @@ spec:
         "path": "./packages/opentelemetry-instrumentation",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-instrumentation
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11892,7 +10352,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-instrumentation-requests/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-instrumentation-requests
@@ -11909,12 +10368,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-instrumentation-requests:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-instrumentation-requests
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-instrumentation-requests/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11924,14 +10377,14 @@ spec:
         "path": "./packages/opentelemetry-instrumentation-requests",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-instrumentation-requests
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11946,7 +10399,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-proto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-proto
@@ -11963,12 +10415,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-proto:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-proto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-proto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11978,14 +10424,14 @@ spec:
         "path": "./packages/opentelemetry-proto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-proto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12000,7 +10446,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-sdk
@@ -12017,12 +10462,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-sdk:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12032,14 +10471,14 @@ spec:
         "path": "./packages/opentelemetry-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12054,7 +10493,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-semantic-conventions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-semantic-conventions
@@ -12071,12 +10509,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-semantic-conventions:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-semantic-conventions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-semantic-conventions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12086,14 +10518,14 @@ spec:
         "path": "./packages/opentelemetry-semantic-conventions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-semantic-conventions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12108,7 +10540,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-util-http/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-util-http
@@ -12125,12 +10556,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-util-http:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/opentelemetry-util-http
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-util-http/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12140,14 +10565,14 @@ spec:
         "path": "./packages/opentelemetry-util-http",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-util-http
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12162,7 +10587,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/oscrypto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: oscrypto
@@ -12179,12 +10603,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/oscrypto:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/oscrypto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/oscrypto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12194,14 +10612,14 @@ spec:
         "path": "./packages/oscrypto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: oscrypto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12216,7 +10634,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/overrides/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: overrides
@@ -12233,12 +10650,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/overrides:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/overrides
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/overrides/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12248,14 +10659,14 @@ spec:
         "path": "./packages/overrides",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: overrides
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12270,7 +10681,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/packaging/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: packaging
@@ -12287,12 +10697,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/packaging:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/packaging
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/packaging/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12302,14 +10706,14 @@ spec:
         "path": "./packages/packaging",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: packaging
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12324,7 +10728,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pandas/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pandas
@@ -12341,12 +10744,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pandas:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pandas
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pandas/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12356,14 +10753,14 @@ spec:
         "path": "./packages/pandas",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pandas
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12378,7 +10775,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pandas-gbq/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pandas-gbq
@@ -12395,12 +10791,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pandas-gbq:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pandas-gbq
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pandas-gbq/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12410,14 +10800,14 @@ spec:
         "path": "./packages/pandas-gbq",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pandas-gbq
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12432,7 +10822,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pandocfilters/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pandocfilters
@@ -12449,12 +10838,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pandocfilters:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pandocfilters
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pandocfilters/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12464,14 +10847,14 @@ spec:
         "path": "./packages/pandocfilters",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pandocfilters
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12486,7 +10869,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/paramiko/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: paramiko
@@ -12503,12 +10885,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/paramiko:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/paramiko
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/paramiko/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12518,14 +10894,14 @@ spec:
         "path": "./packages/paramiko",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: paramiko
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12540,7 +10916,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/parso/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: parso
@@ -12557,12 +10932,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/parso:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/parso
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/parso/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12572,14 +10941,14 @@ spec:
         "path": "./packages/parso",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: parso
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12594,7 +10963,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/patchelf/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: patchelf
@@ -12611,12 +10979,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/patchelf:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/patchelf
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/patchelf/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12626,14 +10988,14 @@ spec:
         "path": "./packages/patchelf",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: patchelf
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12648,7 +11010,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pathspec/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pathspec
@@ -12665,12 +11026,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pathspec:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pathspec
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pathspec/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12680,14 +11035,14 @@ spec:
         "path": "./packages/pathspec",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pathspec
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12702,7 +11057,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pbr/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pbr
@@ -12719,12 +11073,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pbr:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pbr
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pbr/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12734,14 +11082,14 @@ spec:
         "path": "./packages/pbr",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pbr
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12756,7 +11104,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pexpect/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pexpect
@@ -12773,12 +11120,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pexpect:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pexpect
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pexpect/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12788,14 +11129,14 @@ spec:
         "path": "./packages/pexpect",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pexpect
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12810,7 +11151,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pg8000/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pg8000
@@ -12827,12 +11167,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pg8000:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pg8000
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pg8000/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12842,14 +11176,14 @@ spec:
         "path": "./packages/pg8000",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pg8000
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12864,7 +11198,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pillow/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pillow
@@ -12881,12 +11214,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pillow:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pillow
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pillow/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12896,14 +11223,14 @@ spec:
         "path": "./packages/pillow",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pillow
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12918,7 +11245,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pinotdb/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pinotdb
@@ -12935,12 +11261,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pinotdb:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pinotdb
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pinotdb/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12950,14 +11270,14 @@ spec:
         "path": "./packages/pinotdb",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pinotdb
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12972,7 +11292,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pip/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pip
@@ -12989,12 +11308,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pip:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pip
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pip/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13004,14 +11317,14 @@ spec:
         "path": "./packages/pip",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pip
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13026,7 +11339,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pkginfo/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pkginfo
@@ -13043,12 +11355,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pkginfo:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pkginfo
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pkginfo/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13058,14 +11364,14 @@ spec:
         "path": "./packages/pkginfo",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pkginfo
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13080,7 +11386,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pkgutil-resolve-name/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pkgutil-resolve-name
@@ -13097,12 +11402,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pkgutil-resolve-name:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pkgutil-resolve-name
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pkgutil-resolve-name/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13112,14 +11411,14 @@ spec:
         "path": "./packages/pkgutil-resolve-name",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pkgutil-resolve-name
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13134,7 +11433,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/platformdirs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: platformdirs
@@ -13151,12 +11449,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/platformdirs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/platformdirs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/platformdirs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13166,14 +11458,14 @@ spec:
         "path": "./packages/platformdirs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: platformdirs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13188,7 +11480,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pluggy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pluggy
@@ -13205,12 +11496,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pluggy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pluggy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pluggy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13220,14 +11505,14 @@ spec:
         "path": "./packages/pluggy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pluggy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13242,7 +11527,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ply/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ply
@@ -13259,12 +11543,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/ply:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/ply
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ply/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13274,14 +11552,14 @@ spec:
         "path": "./packages/ply",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ply
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13296,7 +11574,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/poetry-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: poetry-core
@@ -13313,12 +11590,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/poetry-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/poetry-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/poetry-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13328,14 +11599,14 @@ spec:
         "path": "./packages/poetry-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: poetry-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13350,7 +11621,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/poetry-plugin-export/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: poetry-plugin-export
@@ -13367,12 +11637,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/poetry-plugin-export:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/poetry-plugin-export
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/poetry-plugin-export/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13382,14 +11646,14 @@ spec:
         "path": "./packages/poetry-plugin-export",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: poetry-plugin-export
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13404,7 +11668,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/portalocker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: portalocker
@@ -13421,12 +11684,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/portalocker:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/portalocker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/portalocker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13436,14 +11693,14 @@ spec:
         "path": "./packages/portalocker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: portalocker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13458,7 +11715,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pre-commit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pre-commit
@@ -13475,12 +11731,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pre-commit:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pre-commit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pre-commit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13490,14 +11740,14 @@ spec:
         "path": "./packages/pre-commit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pre-commit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13512,7 +11762,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/prometheus-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: prometheus-client
@@ -13529,12 +11778,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/prometheus-client:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/prometheus-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/prometheus-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13544,14 +11787,14 @@ spec:
         "path": "./packages/prometheus-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: prometheus-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13566,7 +11809,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/prompt-toolkit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: prompt-toolkit
@@ -13583,12 +11825,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/prompt-toolkit:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/prompt-toolkit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/prompt-toolkit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13598,14 +11834,14 @@ spec:
         "path": "./packages/prompt-toolkit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: prompt-toolkit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13620,7 +11856,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/propcache/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: propcache
@@ -13637,12 +11872,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/propcache:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/propcache
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/propcache/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13652,14 +11881,14 @@ spec:
         "path": "./packages/propcache",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: propcache
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13674,7 +11903,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/proto-plus/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: proto-plus
@@ -13691,12 +11919,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/proto-plus:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/proto-plus
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/proto-plus/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13706,14 +11928,14 @@ spec:
         "path": "./packages/proto-plus",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: proto-plus
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13728,7 +11950,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/protobuf/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: protobuf
@@ -13745,12 +11966,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/protobuf:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/protobuf
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/protobuf/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13760,14 +11975,14 @@ spec:
         "path": "./packages/protobuf",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: protobuf
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13782,7 +11997,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/psutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: psutil
@@ -13799,12 +12013,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/psutil:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/psutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/psutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13814,14 +12022,14 @@ spec:
         "path": "./packages/psutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: psutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13836,7 +12044,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ptyprocess/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ptyprocess
@@ -13853,12 +12060,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/ptyprocess:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/ptyprocess
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ptyprocess/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13868,14 +12069,14 @@ spec:
         "path": "./packages/ptyprocess",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ptyprocess
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13890,7 +12091,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pure-eval/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pure-eval
@@ -13907,12 +12107,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pure-eval:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pure-eval
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pure-eval/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13922,14 +12116,14 @@ spec:
         "path": "./packages/pure-eval",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pure-eval
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13944,7 +12138,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/py/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: py
@@ -13961,12 +12154,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/py:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/py
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/py/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13976,14 +12163,14 @@ spec:
         "path": "./packages/py",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: py
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13998,7 +12185,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/py4j/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: py4j
@@ -14015,12 +12201,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/py4j:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/py4j
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/py4j/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14030,14 +12210,14 @@ spec:
         "path": "./packages/py4j",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: py4j
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14052,7 +12232,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyasn1/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyasn1
@@ -14069,12 +12248,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyasn1:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyasn1
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyasn1/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14084,14 +12257,14 @@ spec:
         "path": "./packages/pyasn1",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyasn1
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14106,7 +12279,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyasn1-modules/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyasn1-modules
@@ -14123,12 +12295,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyasn1-modules:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyasn1-modules
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyasn1-modules/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14138,14 +12304,14 @@ spec:
         "path": "./packages/pyasn1-modules",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyasn1-modules
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14160,7 +12326,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pycodestyle/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pycodestyle
@@ -14177,12 +12342,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pycodestyle:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pycodestyle
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pycodestyle/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14192,14 +12351,14 @@ spec:
         "path": "./packages/pycodestyle",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pycodestyle
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14214,7 +12373,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pycparser/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pycparser
@@ -14231,12 +12389,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pycparser:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pycparser
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pycparser/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14246,14 +12398,14 @@ spec:
         "path": "./packages/pycparser",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pycparser
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14268,7 +12420,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pycryptodomex/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pycryptodomex
@@ -14285,12 +12436,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pycryptodomex:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pycryptodomex
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pycryptodomex/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14300,14 +12445,14 @@ spec:
         "path": "./packages/pycryptodomex",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pycryptodomex
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14322,7 +12467,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pydantic/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pydantic
@@ -14339,12 +12483,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pydantic:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pydantic
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pydantic/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14354,14 +12492,14 @@ spec:
         "path": "./packages/pydantic",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pydantic
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14376,7 +12514,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pydantic-settings/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pydantic-settings
@@ -14393,12 +12530,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pydantic-settings:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pydantic-settings
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pydantic-settings/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14408,14 +12539,14 @@ spec:
         "path": "./packages/pydantic-settings",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pydantic-settings
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14430,7 +12561,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyflakes/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyflakes
@@ -14447,12 +12577,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyflakes:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyflakes
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyflakes/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14462,14 +12586,14 @@ spec:
         "path": "./packages/pyflakes",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyflakes
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14484,7 +12608,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pygithub/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pygithub
@@ -14501,12 +12624,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pygithub:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pygithub
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pygithub/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14516,14 +12633,14 @@ spec:
         "path": "./packages/pygithub",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pygithub
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14538,7 +12655,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pygments/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pygments
@@ -14555,12 +12671,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pygments:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pygments
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pygments/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14570,14 +12680,14 @@ spec:
         "path": "./packages/pygments",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pygments
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14592,7 +12702,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyjwt/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyjwt
@@ -14609,12 +12718,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyjwt:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyjwt
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyjwt/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14624,14 +12727,14 @@ spec:
         "path": "./packages/pyjwt",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyjwt
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14646,7 +12749,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pylint/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pylint
@@ -14663,12 +12765,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pylint:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pylint
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pylint/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14678,14 +12774,14 @@ spec:
         "path": "./packages/pylint",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pylint
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14700,7 +12796,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pymongo/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pymongo
@@ -14717,12 +12812,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pymongo:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pymongo
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pymongo/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14732,14 +12821,14 @@ spec:
         "path": "./packages/pymongo",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pymongo
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14754,7 +12843,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pymysql/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pymysql
@@ -14771,12 +12859,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pymysql:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pymysql
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pymysql/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14786,14 +12868,14 @@ spec:
         "path": "./packages/pymysql",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pymysql
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14808,7 +12890,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyopenssl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyopenssl
@@ -14825,12 +12906,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyopenssl:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyopenssl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyopenssl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14840,14 +12915,14 @@ spec:
         "path": "./packages/pyopenssl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyopenssl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14862,7 +12937,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyparsing/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyparsing
@@ -14879,12 +12953,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyparsing:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyparsing
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyparsing/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14894,14 +12962,14 @@ spec:
         "path": "./packages/pyparsing",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyparsing
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14916,7 +12984,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyproject-api/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyproject-api
@@ -14933,12 +13000,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyproject-api:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyproject-api
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyproject-api/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14948,14 +13009,14 @@ spec:
         "path": "./packages/pyproject-api",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyproject-api
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14970,7 +13031,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyproject-hooks/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyproject-hooks
@@ -14987,12 +13047,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyproject-hooks:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyproject-hooks
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyproject-hooks/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15002,14 +13056,14 @@ spec:
         "path": "./packages/pyproject-hooks",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyproject-hooks
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15024,7 +13078,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyproject-metadata/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyproject-metadata
@@ -15041,12 +13094,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyproject-metadata:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyproject-metadata
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyproject-metadata/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15056,14 +13103,14 @@ spec:
         "path": "./packages/pyproject-metadata",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyproject-metadata
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15078,7 +13125,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyrsistent/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyrsistent
@@ -15095,12 +13141,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyrsistent:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyrsistent
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyrsistent/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15110,14 +13150,14 @@ spec:
         "path": "./packages/pyrsistent",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyrsistent
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15132,7 +13172,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyspark/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyspark
@@ -15149,12 +13188,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyspark:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyspark
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyspark/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15164,14 +13197,14 @@ spec:
         "path": "./packages/pyspark",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyspark
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15186,7 +13219,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest
@@ -15203,12 +13235,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pytest
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15218,14 +13244,14 @@ spec:
         "path": "./packages/pytest",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15240,7 +13266,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-asyncio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-asyncio
@@ -15257,12 +13282,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-asyncio:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pytest-asyncio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-asyncio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15272,14 +13291,14 @@ spec:
         "path": "./packages/pytest-asyncio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-asyncio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15294,7 +13313,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-cov/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-cov
@@ -15311,12 +13329,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-cov:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pytest-cov
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-cov/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15326,14 +13338,14 @@ spec:
         "path": "./packages/pytest-cov",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-cov
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15348,7 +13360,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-mock/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-mock
@@ -15365,12 +13376,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-mock:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pytest-mock
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-mock/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15380,14 +13385,14 @@ spec:
         "path": "./packages/pytest-mock",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-mock
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15402,7 +13407,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-xdist/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-xdist
@@ -15419,12 +13423,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-xdist:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pytest-xdist
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-xdist/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15434,14 +13432,14 @@ spec:
         "path": "./packages/pytest-xdist",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-xdist
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15456,7 +13454,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-dateutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-dateutil
@@ -15473,12 +13470,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/python-dateutil:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/python-dateutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-dateutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15488,14 +13479,14 @@ spec:
         "path": "./packages/python-dateutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-dateutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15510,7 +13501,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-dotenv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-dotenv
@@ -15527,12 +13517,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/python-dotenv:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/python-dotenv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-dotenv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15542,14 +13526,14 @@ spec:
         "path": "./packages/python-dotenv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-dotenv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15564,7 +13548,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-json-logger/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-json-logger
@@ -15581,12 +13564,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/python-json-logger:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/python-json-logger
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-json-logger/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15596,14 +13573,14 @@ spec:
         "path": "./packages/python-json-logger",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-json-logger
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15618,7 +13595,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-multipart/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-multipart
@@ -15635,12 +13611,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/python-multipart:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/python-multipart
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-multipart/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15650,14 +13620,14 @@ spec:
         "path": "./packages/python-multipart",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-multipart
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15672,7 +13642,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-slugify/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-slugify
@@ -15689,12 +13658,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/python-slugify:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/python-slugify
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-slugify/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15704,14 +13667,14 @@ spec:
         "path": "./packages/python-slugify",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-slugify
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15726,7 +13689,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-telegram-bot/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-telegram-bot
@@ -15743,12 +13705,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/python-telegram-bot:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/python-telegram-bot
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-telegram-bot/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15758,14 +13714,14 @@ spec:
         "path": "./packages/python-telegram-bot",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-telegram-bot
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15780,7 +13736,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytz
@@ -15797,12 +13752,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pytz:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pytz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15812,14 +13761,14 @@ spec:
         "path": "./packages/pytz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15834,7 +13783,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyyaml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyyaml
@@ -15851,12 +13799,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/pyyaml:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/pyyaml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyyaml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15866,14 +13808,14 @@ spec:
         "path": "./packages/pyyaml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyyaml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15888,7 +13830,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/readme-renderer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: readme-renderer
@@ -15905,12 +13846,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/readme-renderer:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/readme-renderer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/readme-renderer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15920,14 +13855,14 @@ spec:
         "path": "./packages/readme-renderer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: readme-renderer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15942,7 +13877,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/redis/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: redis
@@ -15959,12 +13893,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/redis:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/redis
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/redis/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15974,14 +13902,14 @@ spec:
         "path": "./packages/redis",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: redis
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15996,7 +13924,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/regex/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: regex
@@ -16013,12 +13940,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/regex:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/regex
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/regex/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16028,14 +13949,14 @@ spec:
         "path": "./packages/regex",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: regex
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16050,7 +13971,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/requests/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: requests
@@ -16067,12 +13987,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/requests:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/requests
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/requests/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16082,14 +13996,14 @@ spec:
         "path": "./packages/requests",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: requests
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16104,7 +14018,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/requests-aws4auth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: requests-aws4auth
@@ -16121,12 +14034,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/requests-aws4auth:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/requests-aws4auth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/requests-aws4auth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16136,14 +14043,14 @@ spec:
         "path": "./packages/requests-aws4auth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: requests-aws4auth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16158,7 +14065,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/requests-file/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: requests-file
@@ -16175,12 +14081,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/requests-file:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/requests-file
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/requests-file/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16190,14 +14090,14 @@ spec:
         "path": "./packages/requests-file",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: requests-file
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16212,7 +14112,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/responses/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: responses
@@ -16229,12 +14128,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/responses:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/responses
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/responses/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16244,14 +14137,14 @@ spec:
         "path": "./packages/responses",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: responses
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16266,7 +14159,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/retry/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: retry
@@ -16283,12 +14175,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/retry:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/retry
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/retry/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16298,14 +14184,14 @@ spec:
         "path": "./packages/retry",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: retry
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16320,7 +14206,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rfc3339-validator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rfc3339-validator
@@ -16337,12 +14222,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/rfc3339-validator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/rfc3339-validator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rfc3339-validator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16352,14 +14231,14 @@ spec:
         "path": "./packages/rfc3339-validator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rfc3339-validator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16374,7 +14253,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rfc3986/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rfc3986
@@ -16391,12 +14269,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/rfc3986:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/rfc3986
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rfc3986/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16406,14 +14278,14 @@ spec:
         "path": "./packages/rfc3986",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rfc3986
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16428,7 +14300,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rfc3986-validator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rfc3986-validator
@@ -16445,12 +14316,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/rfc3986-validator:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/rfc3986-validator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rfc3986-validator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16460,14 +14325,14 @@ spec:
         "path": "./packages/rfc3986-validator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rfc3986-validator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16482,7 +14347,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rich/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rich
@@ -16499,12 +14363,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/rich:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/rich
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rich/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16514,14 +14372,14 @@ spec:
         "path": "./packages/rich",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rich
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16536,7 +14394,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rich-toolkit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rich-toolkit
@@ -16553,12 +14410,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/rich-toolkit:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/rich-toolkit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rich-toolkit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16568,14 +14419,14 @@ spec:
         "path": "./packages/rich-toolkit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rich-toolkit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16590,7 +14441,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rsa/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rsa
@@ -16607,12 +14457,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/rsa:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/rsa
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rsa/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16622,14 +14466,14 @@ spec:
         "path": "./packages/rsa",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rsa
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16644,7 +14488,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/s3fs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: s3fs
@@ -16661,12 +14504,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/s3fs:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/s3fs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/s3fs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16676,14 +14513,14 @@ spec:
         "path": "./packages/s3fs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: s3fs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16698,7 +14535,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/s3transfer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: s3transfer
@@ -16715,12 +14551,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/s3transfer:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/s3transfer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/s3transfer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16730,14 +14560,14 @@ spec:
         "path": "./packages/s3transfer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: s3transfer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16752,7 +14582,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/schema/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: schema
@@ -16769,12 +14598,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/schema:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/schema
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/schema/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16784,14 +14607,14 @@ spec:
         "path": "./packages/schema",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: schema
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16806,7 +14629,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/scikit-build-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: scikit-build-core
@@ -16823,12 +14645,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/scikit-build-core:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/scikit-build-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/scikit-build-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16838,14 +14654,14 @@ spec:
         "path": "./packages/scikit-build-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: scikit-build-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16860,7 +14676,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/scramp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: scramp
@@ -16877,12 +14692,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/scramp:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/scramp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/scramp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16892,14 +14701,14 @@ spec:
         "path": "./packages/scramp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: scramp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16914,7 +14723,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/seaborn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: seaborn
@@ -16931,12 +14739,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/seaborn:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/seaborn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/seaborn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16946,14 +14748,14 @@ spec:
         "path": "./packages/seaborn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: seaborn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16968,7 +14770,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/semver/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: semver
@@ -16985,12 +14786,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/semver:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/semver
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/semver/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17000,14 +14795,14 @@ spec:
         "path": "./packages/semver",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: semver
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17022,7 +14817,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sentry-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sentry-sdk
@@ -17039,12 +14833,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sentry-sdk:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sentry-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sentry-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17054,14 +14842,14 @@ spec:
         "path": "./packages/sentry-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sentry-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17076,7 +14864,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/setproctitle/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: setproctitle
@@ -17093,12 +14880,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/setproctitle:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/setproctitle
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/setproctitle/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17108,14 +14889,14 @@ spec:
         "path": "./packages/setproctitle",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: setproctitle
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17130,7 +14911,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/setuptools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: setuptools
@@ -17147,12 +14927,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/setuptools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/setuptools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/setuptools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17162,14 +14936,14 @@ spec:
         "path": "./packages/setuptools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: setuptools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17184,7 +14958,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/setuptools-scm/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: setuptools-scm
@@ -17201,12 +14974,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/setuptools-scm:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/setuptools-scm
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/setuptools-scm/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17216,14 +14983,14 @@ spec:
         "path": "./packages/setuptools-scm",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: setuptools-scm
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17238,7 +15005,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/shellingham/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: shellingham
@@ -17255,12 +15021,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/shellingham:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/shellingham
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/shellingham/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17270,14 +15030,14 @@ spec:
         "path": "./packages/shellingham",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: shellingham
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17292,7 +15052,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/simplejson/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: simplejson
@@ -17309,12 +15068,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/simplejson:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/simplejson
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/simplejson/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17324,14 +15077,14 @@ spec:
         "path": "./packages/simplejson",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: simplejson
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17346,7 +15099,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/six/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: six
@@ -17363,12 +15115,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/six:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/six
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/six/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17378,14 +15124,14 @@ spec:
         "path": "./packages/six",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: six
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17400,7 +15146,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/slack-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: slack-sdk
@@ -17417,12 +15162,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/slack-sdk:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/slack-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/slack-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17432,14 +15171,14 @@ spec:
         "path": "./packages/slack-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: slack-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17454,7 +15193,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/smart-open/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: smart-open
@@ -17471,12 +15209,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/smart-open:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/smart-open
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/smart-open/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17486,14 +15218,14 @@ spec:
         "path": "./packages/smart-open",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: smart-open
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17508,7 +15240,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/smmap/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: smmap
@@ -17525,12 +15256,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/smmap:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/smmap
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/smmap/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17540,14 +15265,14 @@ spec:
         "path": "./packages/smmap",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: smmap
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17562,7 +15287,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sniffio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sniffio
@@ -17579,12 +15303,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sniffio:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sniffio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sniffio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17594,14 +15312,14 @@ spec:
         "path": "./packages/sniffio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sniffio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17616,7 +15334,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/snowflake-connector-python/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: snowflake-connector-python
@@ -17633,12 +15350,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/snowflake-connector-python:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/snowflake-connector-python
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/snowflake-connector-python/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17648,14 +15359,14 @@ spec:
         "path": "./packages/snowflake-connector-python",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: snowflake-connector-python
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17670,7 +15381,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sortedcontainers/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sortedcontainers
@@ -17687,12 +15397,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sortedcontainers:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sortedcontainers
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sortedcontainers/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17702,14 +15406,14 @@ spec:
         "path": "./packages/sortedcontainers",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sortedcontainers
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17724,7 +15428,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/soupsieve/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: soupsieve
@@ -17741,12 +15444,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/soupsieve:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/soupsieve
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/soupsieve/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17756,14 +15453,14 @@ spec:
         "path": "./packages/soupsieve",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: soupsieve
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17778,7 +15475,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sphinx/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sphinx
@@ -17795,12 +15491,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sphinx:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sphinx
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sphinx/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17810,14 +15500,14 @@ spec:
         "path": "./packages/sphinx",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sphinx
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17832,7 +15522,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlalchemy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlalchemy
@@ -17849,12 +15538,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlalchemy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sqlalchemy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlalchemy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17864,14 +15547,14 @@ spec:
         "path": "./packages/sqlalchemy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlalchemy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17886,7 +15569,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlalchemy-bigquery/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlalchemy-bigquery
@@ -17903,12 +15585,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlalchemy-bigquery:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sqlalchemy-bigquery
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlalchemy-bigquery/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17918,14 +15594,14 @@ spec:
         "path": "./packages/sqlalchemy-bigquery",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlalchemy-bigquery
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17940,7 +15616,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlalchemy-spanner/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlalchemy-spanner
@@ -17957,12 +15632,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlalchemy-spanner:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sqlalchemy-spanner
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlalchemy-spanner/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17972,14 +15641,14 @@ spec:
         "path": "./packages/sqlalchemy-spanner",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlalchemy-spanner
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17994,7 +15663,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlparse/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlparse
@@ -18011,12 +15679,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlparse:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sqlparse
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlparse/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18026,14 +15688,14 @@ spec:
         "path": "./packages/sqlparse",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlparse
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18048,7 +15710,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sshtunnel/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sshtunnel
@@ -18065,12 +15726,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sshtunnel:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sshtunnel
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sshtunnel/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18080,14 +15735,14 @@ spec:
         "path": "./packages/sshtunnel",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sshtunnel
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18102,7 +15757,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/stack-data/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: stack-data
@@ -18119,12 +15773,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/stack-data:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/stack-data
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/stack-data/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18134,14 +15782,14 @@ spec:
         "path": "./packages/stack-data",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: stack-data
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18156,7 +15804,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/starlette/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: starlette
@@ -18173,12 +15820,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/starlette:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/starlette
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/starlette/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18188,14 +15829,14 @@ spec:
         "path": "./packages/starlette",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: starlette
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18210,7 +15851,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sympy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sympy
@@ -18227,12 +15867,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/sympy:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/sympy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sympy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18242,14 +15876,14 @@ spec:
         "path": "./packages/sympy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sympy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18264,7 +15898,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tableauserverclient/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tableauserverclient
@@ -18281,12 +15914,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tableauserverclient:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tableauserverclient
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tableauserverclient/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18296,14 +15923,14 @@ spec:
         "path": "./packages/tableauserverclient",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tableauserverclient
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18318,7 +15945,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tabulate/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tabulate
@@ -18335,12 +15961,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tabulate:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tabulate
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tabulate/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18350,14 +15970,14 @@ spec:
         "path": "./packages/tabulate",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tabulate
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18372,7 +15992,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tblib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tblib
@@ -18389,12 +16008,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tblib:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tblib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tblib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18404,14 +16017,14 @@ spec:
         "path": "./packages/tblib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tblib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18426,7 +16039,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tenacity/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tenacity
@@ -18443,12 +16055,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tenacity:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tenacity
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tenacity/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18458,14 +16064,14 @@ spec:
         "path": "./packages/tenacity",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tenacity
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18480,7 +16086,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/termcolor/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: termcolor
@@ -18497,12 +16102,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/termcolor:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/termcolor
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/termcolor/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18512,14 +16111,14 @@ spec:
         "path": "./packages/termcolor",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: termcolor
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18534,7 +16133,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/terminado/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: terminado
@@ -18551,12 +16149,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/terminado:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/terminado
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/terminado/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18566,14 +16158,14 @@ spec:
         "path": "./packages/terminado",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: terminado
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18588,7 +16180,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/threadpoolctl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: threadpoolctl
@@ -18605,12 +16196,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/threadpoolctl:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/threadpoolctl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/threadpoolctl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18620,14 +16205,14 @@ spec:
         "path": "./packages/threadpoolctl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: threadpoolctl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18642,7 +16227,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/thrift/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: thrift
@@ -18659,12 +16243,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/thrift:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/thrift
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/thrift/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18674,14 +16252,14 @@ spec:
         "path": "./packages/thrift",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: thrift
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18696,7 +16274,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/thriftpy2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: thriftpy2
@@ -18713,12 +16290,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/thriftpy2:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/thriftpy2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/thriftpy2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18728,14 +16299,14 @@ spec:
         "path": "./packages/thriftpy2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: thriftpy2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18750,7 +16321,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tinycss2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tinycss2
@@ -18767,12 +16337,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tinycss2:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tinycss2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tinycss2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18782,14 +16346,14 @@ spec:
         "path": "./packages/tinycss2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tinycss2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18804,7 +16368,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/toml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: toml
@@ -18821,12 +16384,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/toml:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/toml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/toml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18836,14 +16393,14 @@ spec:
         "path": "./packages/toml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: toml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18858,7 +16415,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tomlkit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tomlkit
@@ -18875,12 +16431,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tomlkit:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tomlkit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tomlkit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18890,14 +16440,14 @@ spec:
         "path": "./packages/tomlkit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tomlkit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18912,7 +16462,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/toolz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: toolz
@@ -18929,12 +16478,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/toolz:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/toolz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/toolz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18944,14 +16487,14 @@ spec:
         "path": "./packages/toolz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: toolz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18966,7 +16509,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tornado/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tornado
@@ -18983,12 +16525,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tornado:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tornado
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tornado/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18998,14 +16534,14 @@ spec:
         "path": "./packages/tornado",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tornado
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19020,7 +16556,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tox/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tox
@@ -19037,12 +16572,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tox:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tox
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tox/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19052,14 +16581,14 @@ spec:
         "path": "./packages/tox",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tox
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19074,7 +16603,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tqdm/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tqdm
@@ -19091,12 +16619,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tqdm:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tqdm
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tqdm/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19106,14 +16628,14 @@ spec:
         "path": "./packages/tqdm",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tqdm
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19128,7 +16650,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/traitlets/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: traitlets
@@ -19145,12 +16666,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/traitlets:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/traitlets
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/traitlets/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19160,14 +16675,14 @@ spec:
         "path": "./packages/traitlets",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: traitlets
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19182,7 +16697,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/trove-classifiers/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: trove-classifiers
@@ -19199,12 +16713,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/trove-classifiers:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/trove-classifiers
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/trove-classifiers/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19214,14 +16722,14 @@ spec:
         "path": "./packages/trove-classifiers",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: trove-classifiers
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19236,7 +16744,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typeguard/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typeguard
@@ -19253,12 +16760,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/typeguard:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/typeguard
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typeguard/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19268,14 +16769,14 @@ spec:
         "path": "./packages/typeguard",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typeguard
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19290,7 +16791,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typer
@@ -19307,12 +16807,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/typer:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/typer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19322,14 +16816,14 @@ spec:
         "path": "./packages/typer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19344,7 +16838,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-protobuf/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-protobuf
@@ -19361,12 +16854,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-protobuf:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-protobuf
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-protobuf/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19376,14 +16863,14 @@ spec:
         "path": "./packages/types-protobuf",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-protobuf
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19398,7 +16885,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-psutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-psutil
@@ -19415,12 +16901,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-psutil:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-psutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-psutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19430,14 +16910,14 @@ spec:
         "path": "./packages/types-psutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-psutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19452,7 +16932,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-python-dateutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-python-dateutil
@@ -19469,12 +16948,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-python-dateutil:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-python-dateutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-python-dateutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19484,14 +16957,14 @@ spec:
         "path": "./packages/types-python-dateutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-python-dateutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19506,7 +16979,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-pytz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-pytz
@@ -19523,12 +16995,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-pytz:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-pytz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-pytz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19538,14 +17004,14 @@ spec:
         "path": "./packages/types-pytz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-pytz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19560,7 +17026,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-pyyaml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-pyyaml
@@ -19577,12 +17042,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-pyyaml:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-pyyaml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-pyyaml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19592,14 +17051,14 @@ spec:
         "path": "./packages/types-pyyaml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-pyyaml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19614,7 +17073,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-requests/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-requests
@@ -19631,12 +17089,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-requests:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-requests
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-requests/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19646,14 +17098,14 @@ spec:
         "path": "./packages/types-requests",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-requests
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19668,7 +17120,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-setuptools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-setuptools
@@ -19685,12 +17136,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/types-setuptools:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/types-setuptools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-setuptools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19700,14 +17145,14 @@ spec:
         "path": "./packages/types-setuptools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-setuptools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19722,7 +17167,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typing-extensions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typing-extensions
@@ -19739,12 +17183,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/typing-extensions:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/typing-extensions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typing-extensions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19754,14 +17192,14 @@ spec:
         "path": "./packages/typing-extensions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typing-extensions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19776,7 +17214,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typing-inspect/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typing-inspect
@@ -19793,12 +17230,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/typing-inspect:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/typing-inspect
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typing-inspect/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19808,14 +17239,14 @@ spec:
         "path": "./packages/typing-inspect",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typing-inspect
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19830,7 +17261,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typing-inspection/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typing-inspection
@@ -19847,12 +17277,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/typing-inspection:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/typing-inspection
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typing-inspection/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19862,14 +17286,14 @@ spec:
         "path": "./packages/typing-inspection",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typing-inspection
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19884,7 +17308,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tzdata/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tzdata
@@ -19901,12 +17324,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tzdata:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tzdata
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tzdata/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19916,14 +17333,14 @@ spec:
         "path": "./packages/tzdata",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tzdata
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19938,7 +17355,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tzlocal/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tzlocal
@@ -19955,12 +17371,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/tzlocal:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/tzlocal
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tzlocal/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19970,14 +17380,14 @@ spec:
         "path": "./packages/tzlocal",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tzlocal
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19992,7 +17402,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/urllib3/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: urllib3
@@ -20009,12 +17418,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/urllib3:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/urllib3
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/urllib3/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20024,14 +17427,14 @@ spec:
         "path": "./packages/urllib3",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: urllib3
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20046,7 +17449,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/uvicorn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: uvicorn
@@ -20063,12 +17465,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/uvicorn:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/uvicorn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/uvicorn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20078,14 +17474,14 @@ spec:
         "path": "./packages/uvicorn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: uvicorn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20100,7 +17496,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/uvloop/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: uvloop
@@ -20117,12 +17512,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/uvloop:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/uvloop
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/uvloop/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20132,14 +17521,14 @@ spec:
         "path": "./packages/uvloop",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: uvloop
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20154,7 +17543,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/virtualenv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: virtualenv
@@ -20171,12 +17559,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/virtualenv:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/virtualenv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/virtualenv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20186,14 +17568,14 @@ spec:
         "path": "./packages/virtualenv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: virtualenv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20208,7 +17590,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/watchdog/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: watchdog
@@ -20225,12 +17606,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/watchdog:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/watchdog
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/watchdog/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20240,14 +17615,14 @@ spec:
         "path": "./packages/watchdog",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: watchdog
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20262,7 +17637,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wcwidth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wcwidth
@@ -20279,12 +17653,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/wcwidth:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/wcwidth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wcwidth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20294,14 +17662,14 @@ spec:
         "path": "./packages/wcwidth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wcwidth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20316,7 +17684,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/weaviate-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: weaviate-client
@@ -20333,12 +17700,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/weaviate-client:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/weaviate-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/weaviate-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20348,14 +17709,14 @@ spec:
         "path": "./packages/weaviate-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: weaviate-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20370,7 +17731,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/webcolors/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: webcolors
@@ -20387,12 +17747,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/webcolors:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/webcolors
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/webcolors/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20402,14 +17756,14 @@ spec:
         "path": "./packages/webcolors",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: webcolors
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20424,7 +17778,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/webencodings/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: webencodings
@@ -20441,12 +17794,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/webencodings:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/webencodings
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/webencodings/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20456,14 +17803,14 @@ spec:
         "path": "./packages/webencodings",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: webencodings
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20478,7 +17825,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/websocket-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: websocket-client
@@ -20495,12 +17841,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/websocket-client:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/websocket-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/websocket-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20510,14 +17850,14 @@ spec:
         "path": "./packages/websocket-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: websocket-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20532,7 +17872,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/websockets/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: websockets
@@ -20549,12 +17888,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/websockets:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/websockets
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/websockets/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20564,14 +17897,14 @@ spec:
         "path": "./packages/websockets",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: websockets
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20586,7 +17919,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/werkzeug/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: werkzeug
@@ -20603,12 +17935,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/werkzeug:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/werkzeug
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/werkzeug/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20618,14 +17944,14 @@ spec:
         "path": "./packages/werkzeug",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: werkzeug
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20640,7 +17966,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wheel/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wheel
@@ -20657,12 +17982,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/wheel:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/wheel
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wheel/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20672,14 +17991,14 @@ spec:
         "path": "./packages/wheel",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wheel
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20694,7 +18013,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/widgetsnbextension/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: widgetsnbextension
@@ -20711,12 +18029,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/widgetsnbextension:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/widgetsnbextension
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/widgetsnbextension/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20726,14 +18038,14 @@ spec:
         "path": "./packages/widgetsnbextension",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: widgetsnbextension
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20748,7 +18060,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wrapt/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wrapt
@@ -20765,12 +18076,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/wrapt:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/wrapt
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wrapt/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20780,14 +18085,14 @@ spec:
         "path": "./packages/wrapt",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wrapt
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20802,7 +18107,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wsproto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wsproto
@@ -20819,12 +18123,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/wsproto:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/wsproto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wsproto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20834,14 +18132,14 @@ spec:
         "path": "./packages/wsproto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wsproto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20856,7 +18154,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/xlsxwriter/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: xlsxwriter
@@ -20873,12 +18170,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/xlsxwriter:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/xlsxwriter
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/xlsxwriter/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20888,14 +18179,14 @@ spec:
         "path": "./packages/xlsxwriter",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: xlsxwriter
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20910,7 +18201,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/xmltodict/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: xmltodict
@@ -20927,12 +18217,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/xmltodict:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/xmltodict
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/xmltodict/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20942,14 +18226,14 @@ spec:
         "path": "./packages/xmltodict",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: xmltodict
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20964,7 +18248,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/xyzservices/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: xyzservices
@@ -20981,12 +18264,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/xyzservices:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/xyzservices
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/xyzservices/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20996,14 +18273,14 @@ spec:
         "path": "./packages/xyzservices",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: xyzservices
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -21018,7 +18295,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/yamllint/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: yamllint
@@ -21035,12 +18311,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/yamllint:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/yamllint
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/yamllint/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -21050,14 +18320,14 @@ spec:
         "path": "./packages/yamllint",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: yamllint
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -21072,7 +18342,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/yandexcloud/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: yandexcloud
@@ -21089,12 +18358,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/yandexcloud:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/yandexcloud
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/yandexcloud/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -21104,14 +18367,14 @@ spec:
         "path": "./packages/yandexcloud",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: yandexcloud
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -21126,7 +18389,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/yarl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: yarl
@@ -21143,12 +18405,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/yarl:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/yarl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/yarl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -21158,14 +18414,14 @@ spec:
         "path": "./packages/yarl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: yarl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -21180,7 +18436,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/zipp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: zipp
@@ -21197,12 +18452,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/zipp:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/zipp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/zipp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -21212,14 +18461,14 @@ spec:
         "path": "./packages/zipp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: zipp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -21234,7 +18483,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/zstandard/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: zstandard
@@ -21251,12 +18499,6 @@ spec:
     value: quay.io/redhat-user-workloads/calunga-tenant/zstandard:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
-  - name: path-context
-    value: packages/zstandard
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/zstandard/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -21266,11 +18508,11 @@ spec:
         "path": "./packages/zstandard",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: zstandard
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}

--- a/.tekton/packages-on-push.yaml
+++ b/.tekton/packages-on-push.yaml
@@ -11,7 +11,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/absl-py/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: absl-py
@@ -26,12 +25,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/absl-py:{{revision}}
-  - name: path-context
-    value: packages/absl-py
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/absl-py/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -41,14 +34,14 @@ spec:
         "path": "./packages/absl-py",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: absl-py
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -62,7 +55,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/adal/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: adal
@@ -77,12 +69,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/adal:{{revision}}
-  - name: path-context
-    value: packages/adal
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/adal/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -92,14 +78,14 @@ spec:
         "path": "./packages/adal",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: adal
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -113,7 +99,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiobotocore/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiobotocore
@@ -128,12 +113,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/aiobotocore:{{revision}}
-  - name: path-context
-    value: packages/aiobotocore
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiobotocore/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -143,14 +122,14 @@ spec:
         "path": "./packages/aiobotocore",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiobotocore
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -164,7 +143,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiofiles/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiofiles
@@ -179,12 +157,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/aiofiles:{{revision}}
-  - name: path-context
-    value: packages/aiofiles
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiofiles/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -194,14 +166,14 @@ spec:
         "path": "./packages/aiofiles",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiofiles
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -215,7 +187,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiohappyeyeballs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiohappyeyeballs
@@ -230,12 +201,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/aiohappyeyeballs:{{revision}}
-  - name: path-context
-    value: packages/aiohappyeyeballs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiohappyeyeballs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -245,14 +210,14 @@ spec:
         "path": "./packages/aiohappyeyeballs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiohappyeyeballs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -266,7 +231,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aiohttp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aiohttp
@@ -281,12 +245,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/aiohttp:{{revision}}
-  - name: path-context
-    value: packages/aiohttp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aiohttp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -296,14 +254,14 @@ spec:
         "path": "./packages/aiohttp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aiohttp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -317,7 +275,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aioitertools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aioitertools
@@ -332,12 +289,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/aioitertools:{{revision}}
-  - name: path-context
-    value: packages/aioitertools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aioitertools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -347,14 +298,14 @@ spec:
         "path": "./packages/aioitertools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aioitertools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -368,7 +319,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/alembic/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: alembic
@@ -383,12 +333,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/alembic:{{revision}}
-  - name: path-context
-    value: packages/alembic
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/alembic/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -398,14 +342,14 @@ spec:
         "path": "./packages/alembic",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: alembic
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -419,7 +363,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/annotated-types/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: annotated-types
@@ -434,12 +377,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/annotated-types:{{revision}}
-  - name: path-context
-    value: packages/annotated-types
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/annotated-types/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -449,14 +386,14 @@ spec:
         "path": "./packages/annotated-types",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: annotated-types
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -470,7 +407,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/anyio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: anyio
@@ -485,12 +421,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/anyio:{{revision}}
-  - name: path-context
-    value: packages/anyio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/anyio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -500,14 +430,14 @@ spec:
         "path": "./packages/anyio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: anyio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -521,7 +451,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/appdirs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: appdirs
@@ -536,12 +465,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/appdirs:{{revision}}
-  - name: path-context
-    value: packages/appdirs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/appdirs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -551,14 +474,14 @@ spec:
         "path": "./packages/appdirs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: appdirs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -572,7 +495,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/argcomplete/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: argcomplete
@@ -587,12 +509,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/argcomplete:{{revision}}
-  - name: path-context
-    value: packages/argcomplete
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/argcomplete/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -602,14 +518,14 @@ spec:
         "path": "./packages/argcomplete",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: argcomplete
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -623,7 +539,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/argon2-cffi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: argon2-cffi
@@ -638,12 +553,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/argon2-cffi:{{revision}}
-  - name: path-context
-    value: packages/argon2-cffi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/argon2-cffi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -653,14 +562,14 @@ spec:
         "path": "./packages/argon2-cffi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: argon2-cffi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -674,7 +583,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/arrow/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: arrow
@@ -689,12 +597,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/arrow:{{revision}}
-  - name: path-context
-    value: packages/arrow
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/arrow/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -704,14 +606,14 @@ spec:
         "path": "./packages/arrow",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: arrow
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -725,7 +627,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/asgiref/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: asgiref
@@ -740,12 +641,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/asgiref:{{revision}}
-  - name: path-context
-    value: packages/asgiref
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/asgiref/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -755,14 +650,14 @@ spec:
         "path": "./packages/asgiref",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: asgiref
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -776,7 +671,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/asn1crypto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: asn1crypto
@@ -791,12 +685,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/asn1crypto:{{revision}}
-  - name: path-context
-    value: packages/asn1crypto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/asn1crypto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -806,14 +694,14 @@ spec:
         "path": "./packages/asn1crypto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: asn1crypto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -827,7 +715,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/astroid/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: astroid
@@ -842,12 +729,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/astroid:{{revision}}
-  - name: path-context
-    value: packages/astroid
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/astroid/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -857,14 +738,14 @@ spec:
         "path": "./packages/astroid",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: astroid
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -878,7 +759,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/asttokens/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: asttokens
@@ -893,12 +773,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/asttokens:{{revision}}
-  - name: path-context
-    value: packages/asttokens
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/asttokens/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -908,14 +782,14 @@ spec:
         "path": "./packages/asttokens",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: asttokens
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -929,7 +803,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/async-lru/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: async-lru
@@ -944,12 +817,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/async-lru:{{revision}}
-  - name: path-context
-    value: packages/async-lru
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/async-lru/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -959,14 +826,14 @@ spec:
         "path": "./packages/async-lru",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: async-lru
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -980,7 +847,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/async-timeout/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: async-timeout
@@ -995,12 +861,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/async-timeout:{{revision}}
-  - name: path-context
-    value: packages/async-timeout
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/async-timeout/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1010,14 +870,14 @@ spec:
         "path": "./packages/async-timeout",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: async-timeout
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1031,7 +891,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/attrs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: attrs
@@ -1046,12 +905,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/attrs:{{revision}}
-  - name: path-context
-    value: packages/attrs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/attrs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1061,14 +914,14 @@ spec:
         "path": "./packages/attrs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: attrs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1082,7 +935,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/authlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: authlib
@@ -1097,12 +949,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/authlib:{{revision}}
-  - name: path-context
-    value: packages/authlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/authlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1112,14 +958,14 @@ spec:
         "path": "./packages/authlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: authlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1133,7 +979,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/aws-lambda-powertools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: aws-lambda-powertools
@@ -1148,12 +993,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/aws-lambda-powertools:{{revision}}
-  - name: path-context
-    value: packages/aws-lambda-powertools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/aws-lambda-powertools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1163,14 +1002,14 @@ spec:
         "path": "./packages/aws-lambda-powertools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: aws-lambda-powertools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1184,7 +1023,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/awscli/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: awscli
@@ -1199,12 +1037,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/awscli:{{revision}}
-  - name: path-context
-    value: packages/awscli
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/awscli/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1214,14 +1046,14 @@ spec:
         "path": "./packages/awscli",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: awscli
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1235,7 +1067,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/awswrangler/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: awswrangler
@@ -1250,12 +1081,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/awswrangler:{{revision}}
-  - name: path-context
-    value: packages/awswrangler
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/awswrangler/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1265,14 +1090,14 @@ spec:
         "path": "./packages/awswrangler",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: awswrangler
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1286,7 +1111,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-core
@@ -1301,12 +1125,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-core:{{revision}}
-  - name: path-context
-    value: packages/azure-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1316,14 +1134,14 @@ spec:
         "path": "./packages/azure-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1337,7 +1155,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-identity/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-identity
@@ -1352,12 +1169,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-identity:{{revision}}
-  - name: path-context
-    value: packages/azure-identity
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-identity/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1367,14 +1178,14 @@ spec:
         "path": "./packages/azure-identity",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-identity
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1388,7 +1199,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-keyvault-secrets/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-keyvault-secrets
@@ -1403,12 +1213,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-keyvault-secrets:{{revision}}
-  - name: path-context
-    value: packages/azure-keyvault-secrets
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-keyvault-secrets/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1418,14 +1222,14 @@ spec:
         "path": "./packages/azure-keyvault-secrets",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-keyvault-secrets
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1439,7 +1243,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-storage-blob/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-storage-blob
@@ -1454,12 +1257,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-storage-blob:{{revision}}
-  - name: path-context
-    value: packages/azure-storage-blob
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-storage-blob/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1469,14 +1266,14 @@ spec:
         "path": "./packages/azure-storage-blob",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-storage-blob
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1490,7 +1287,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/azure-storage-file-datalake/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: azure-storage-file-datalake
@@ -1505,12 +1301,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/azure-storage-file-datalake:{{revision}}
-  - name: path-context
-    value: packages/azure-storage-file-datalake
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/azure-storage-file-datalake/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1520,14 +1310,14 @@ spec:
         "path": "./packages/azure-storage-file-datalake",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: azure-storage-file-datalake
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1541,7 +1331,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/babel/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: babel
@@ -1556,12 +1345,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/babel:{{revision}}
-  - name: path-context
-    value: packages/babel
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/babel/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1571,14 +1354,14 @@ spec:
         "path": "./packages/babel",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: babel
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1592,7 +1375,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/backoff/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: backoff
@@ -1607,12 +1389,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/backoff:{{revision}}
-  - name: path-context
-    value: packages/backoff
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/backoff/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1622,14 +1398,14 @@ spec:
         "path": "./packages/backoff",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: backoff
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1643,7 +1419,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/backports-tarfile/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: backports-tarfile
@@ -1658,12 +1433,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/backports-tarfile:{{revision}}
-  - name: path-context
-    value: packages/backports-tarfile
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/backports-tarfile/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1673,14 +1442,14 @@ spec:
         "path": "./packages/backports-tarfile",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: backports-tarfile
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1694,7 +1463,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/beautifulsoup4/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: beautifulsoup4
@@ -1709,12 +1477,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/beautifulsoup4:{{revision}}
-  - name: path-context
-    value: packages/beautifulsoup4
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/beautifulsoup4/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1724,14 +1486,14 @@ spec:
         "path": "./packages/beautifulsoup4",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: beautifulsoup4
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1745,7 +1507,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/black/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: black
@@ -1760,12 +1521,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/black:{{revision}}
-  - name: path-context
-    value: packages/black
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/black/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1775,14 +1530,14 @@ spec:
         "path": "./packages/black",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: black
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1796,7 +1551,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/bleach/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: bleach
@@ -1811,12 +1565,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/bleach:{{revision}}
-  - name: path-context
-    value: packages/bleach
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/bleach/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1826,14 +1574,14 @@ spec:
         "path": "./packages/bleach",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: bleach
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1847,7 +1595,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/blinker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: blinker
@@ -1862,12 +1609,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/blinker:{{revision}}
-  - name: path-context
-    value: packages/blinker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/blinker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1877,14 +1618,14 @@ spec:
         "path": "./packages/blinker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: blinker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1898,7 +1639,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/bokeh/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: bokeh
@@ -1913,12 +1653,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/bokeh:{{revision}}
-  - name: path-context
-    value: packages/bokeh
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/bokeh/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1928,14 +1662,14 @@ spec:
         "path": "./packages/bokeh",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: bokeh
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -1949,7 +1683,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/boto3/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: boto3
@@ -1964,12 +1697,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/boto3:{{revision}}
-  - name: path-context
-    value: packages/boto3
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/boto3/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -1979,14 +1706,14 @@ spec:
         "path": "./packages/boto3",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: boto3
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2000,7 +1727,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/botocore/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: botocore
@@ -2015,12 +1741,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/botocore:{{revision}}
-  - name: path-context
-    value: packages/botocore
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/botocore/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2030,14 +1750,14 @@ spec:
         "path": "./packages/botocore",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: botocore
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2051,7 +1771,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/build/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: build
@@ -2066,12 +1785,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/build:{{revision}}
-  - name: path-context
-    value: packages/build
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/build/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2081,14 +1794,14 @@ spec:
         "path": "./packages/build",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: build
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2102,7 +1815,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cachecontrol/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cachecontrol
@@ -2117,12 +1829,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cachecontrol:{{revision}}
-  - name: path-context
-    value: packages/cachecontrol
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cachecontrol/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2132,14 +1838,14 @@ spec:
         "path": "./packages/cachecontrol",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cachecontrol
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2153,7 +1859,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cachetools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cachetools
@@ -2168,12 +1873,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cachetools:{{revision}}
-  - name: path-context
-    value: packages/cachetools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cachetools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2183,14 +1882,14 @@ spec:
         "path": "./packages/cachetools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cachetools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2204,7 +1903,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/calver/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: calver
@@ -2219,12 +1917,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/calver:{{revision}}
-  - name: path-context
-    value: packages/calver
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/calver/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2234,14 +1926,14 @@ spec:
         "path": "./packages/calver",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: calver
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2255,7 +1947,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cattrs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cattrs
@@ -2270,12 +1961,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cattrs:{{revision}}
-  - name: path-context
-    value: packages/cattrs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cattrs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2285,14 +1970,14 @@ spec:
         "path": "./packages/cattrs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cattrs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2306,7 +1991,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cffi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cffi
@@ -2321,12 +2005,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cffi:{{revision}}
-  - name: path-context
-    value: packages/cffi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cffi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2336,14 +2014,14 @@ spec:
         "path": "./packages/cffi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cffi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2357,7 +2035,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cfgv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cfgv
@@ -2372,12 +2049,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cfgv:{{revision}}
-  - name: path-context
-    value: packages/cfgv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cfgv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2387,14 +2058,14 @@ spec:
         "path": "./packages/cfgv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cfgv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2408,7 +2079,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/chardet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: chardet
@@ -2423,12 +2093,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/chardet:{{revision}}
-  - name: path-context
-    value: packages/chardet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/chardet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2438,14 +2102,14 @@ spec:
         "path": "./packages/chardet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: chardet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2459,7 +2123,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/charset-normalizer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: charset-normalizer
@@ -2474,12 +2137,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/charset-normalizer:{{revision}}
-  - name: path-context
-    value: packages/charset-normalizer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/charset-normalizer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2489,14 +2146,14 @@ spec:
         "path": "./packages/charset-normalizer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: charset-normalizer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2510,7 +2167,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cleo/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cleo
@@ -2525,12 +2181,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cleo:{{revision}}
-  - name: path-context
-    value: packages/cleo
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cleo/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2540,14 +2190,14 @@ spec:
         "path": "./packages/cleo",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cleo
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2561,7 +2211,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/click/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: click
@@ -2576,12 +2225,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/click:{{revision}}
-  - name: path-context
-    value: packages/click
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/click/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2591,14 +2234,14 @@ spec:
         "path": "./packages/click",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: click
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2612,7 +2255,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/click-plugins/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: click-plugins
@@ -2627,12 +2269,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/click-plugins:{{revision}}
-  - name: path-context
-    value: packages/click-plugins
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/click-plugins/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2642,14 +2278,14 @@ spec:
         "path": "./packages/click-plugins",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: click-plugins
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2663,7 +2299,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cloudpickle/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cloudpickle
@@ -2678,12 +2313,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cloudpickle:{{revision}}
-  - name: path-context
-    value: packages/cloudpickle
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cloudpickle/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2693,14 +2322,14 @@ spec:
         "path": "./packages/cloudpickle",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cloudpickle
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2714,7 +2343,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/colorama/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: colorama
@@ -2729,12 +2357,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/colorama:{{revision}}
-  - name: path-context
-    value: packages/colorama
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/colorama/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2744,14 +2366,14 @@ spec:
         "path": "./packages/colorama",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: colorama
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2765,7 +2387,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/colorlog/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: colorlog
@@ -2780,12 +2401,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/colorlog:{{revision}}
-  - name: path-context
-    value: packages/colorlog
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/colorlog/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2795,14 +2410,14 @@ spec:
         "path": "./packages/colorlog",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: colorlog
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2816,7 +2431,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/comm/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: comm
@@ -2831,12 +2445,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/comm:{{revision}}
-  - name: path-context
-    value: packages/comm
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/comm/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2846,14 +2454,14 @@ spec:
         "path": "./packages/comm",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: comm
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2867,7 +2475,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/coverage/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: coverage
@@ -2882,12 +2489,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/coverage:{{revision}}
-  - name: path-context
-    value: packages/coverage
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/coverage/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2897,14 +2498,14 @@ spec:
         "path": "./packages/coverage",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: coverage
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2918,7 +2519,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/crashtest/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: crashtest
@@ -2933,12 +2533,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/crashtest:{{revision}}
-  - name: path-context
-    value: packages/crashtest
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/crashtest/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2948,14 +2542,14 @@ spec:
         "path": "./packages/crashtest",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: crashtest
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -2969,7 +2563,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/croniter/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: croniter
@@ -2984,12 +2577,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/croniter:{{revision}}
-  - name: path-context
-    value: packages/croniter
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/croniter/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -2999,14 +2586,14 @@ spec:
         "path": "./packages/croniter",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: croniter
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3020,7 +2607,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cycler/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cycler
@@ -3035,12 +2621,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cycler:{{revision}}
-  - name: path-context
-    value: packages/cycler
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cycler/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3050,14 +2630,14 @@ spec:
         "path": "./packages/cycler",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cycler
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3071,7 +2651,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/cython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: cython
@@ -3086,12 +2665,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/cython:{{revision}}
-  - name: path-context
-    value: packages/cython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/cython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3101,14 +2674,14 @@ spec:
         "path": "./packages/cython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: cython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3122,7 +2695,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/databricks-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: databricks-sdk
@@ -3137,12 +2709,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/databricks-sdk:{{revision}}
-  - name: path-context
-    value: packages/databricks-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/databricks-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3152,14 +2718,14 @@ spec:
         "path": "./packages/databricks-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: databricks-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3173,7 +2739,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/databricks-sql-connector/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: databricks-sql-connector
@@ -3188,12 +2753,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/databricks-sql-connector:{{revision}}
-  - name: path-context
-    value: packages/databricks-sql-connector
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/databricks-sql-connector/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3203,14 +2762,14 @@ spec:
         "path": "./packages/databricks-sql-connector",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: databricks-sql-connector
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3224,7 +2783,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/dataclasses-json/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: dataclasses-json
@@ -3239,12 +2797,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/dataclasses-json:{{revision}}
-  - name: path-context
-    value: packages/dataclasses-json
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/dataclasses-json/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3254,14 +2806,14 @@ spec:
         "path": "./packages/dataclasses-json",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: dataclasses-json
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3275,7 +2827,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/datadog/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: datadog
@@ -3290,12 +2841,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/datadog:{{revision}}
-  - name: path-context
-    value: packages/datadog
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/datadog/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3305,14 +2850,14 @@ spec:
         "path": "./packages/datadog",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: datadog
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3326,7 +2871,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/debugpy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: debugpy
@@ -3341,12 +2885,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/debugpy:{{revision}}
-  - name: path-context
-    value: packages/debugpy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/debugpy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3356,14 +2894,14 @@ spec:
         "path": "./packages/debugpy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: debugpy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3377,7 +2915,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/decorator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: decorator
@@ -3392,12 +2929,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/decorator:{{revision}}
-  - name: path-context
-    value: packages/decorator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/decorator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3407,14 +2938,14 @@ spec:
         "path": "./packages/decorator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: decorator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3428,7 +2959,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/deepdiff/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: deepdiff
@@ -3443,12 +2973,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/deepdiff:{{revision}}
-  - name: path-context
-    value: packages/deepdiff
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/deepdiff/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3458,14 +2982,14 @@ spec:
         "path": "./packages/deepdiff",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: deepdiff
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3479,7 +3003,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/defusedxml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: defusedxml
@@ -3494,12 +3017,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/defusedxml:{{revision}}
-  - name: path-context
-    value: packages/defusedxml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/defusedxml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3509,14 +3026,14 @@ spec:
         "path": "./packages/defusedxml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: defusedxml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3530,7 +3047,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/deprecated/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: deprecated
@@ -3545,12 +3061,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/deprecated:{{revision}}
-  - name: path-context
-    value: packages/deprecated
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/deprecated/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3560,14 +3070,14 @@ spec:
         "path": "./packages/deprecated",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: deprecated
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3581,7 +3091,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/distlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: distlib
@@ -3596,12 +3105,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/distlib:{{revision}}
-  - name: path-context
-    value: packages/distlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/distlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3611,14 +3114,14 @@ spec:
         "path": "./packages/distlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: distlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3632,7 +3135,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/distro/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: distro
@@ -3647,12 +3149,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/distro:{{revision}}
-  - name: path-context
-    value: packages/distro
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/distro/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3662,14 +3158,14 @@ spec:
         "path": "./packages/distro",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: distro
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3683,7 +3179,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/django/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: django
@@ -3698,12 +3193,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/django:{{revision}}
-  - name: path-context
-    value: packages/django
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/django/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3713,14 +3202,14 @@ spec:
         "path": "./packages/django",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: django
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3734,7 +3223,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/dnspython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: dnspython
@@ -3749,12 +3237,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/dnspython:{{revision}}
-  - name: path-context
-    value: packages/dnspython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/dnspython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3764,14 +3246,14 @@ spec:
         "path": "./packages/dnspython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: dnspython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3785,7 +3267,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/docker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: docker
@@ -3800,12 +3281,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/docker:{{revision}}
-  - name: path-context
-    value: packages/docker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/docker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3815,14 +3290,14 @@ spec:
         "path": "./packages/docker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: docker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3836,7 +3311,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/docstring-parser/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: docstring-parser
@@ -3851,12 +3325,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/docstring-parser:{{revision}}
-  - name: path-context
-    value: packages/docstring-parser
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/docstring-parser/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3866,14 +3334,14 @@ spec:
         "path": "./packages/docstring-parser",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: docstring-parser
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3887,7 +3355,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/docutils/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: docutils
@@ -3902,12 +3369,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/docutils:{{revision}}
-  - name: path-context
-    value: packages/docutils
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/docutils/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3917,14 +3378,14 @@ spec:
         "path": "./packages/docutils",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: docutils
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3938,7 +3399,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/dulwich/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: dulwich
@@ -3953,12 +3413,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/dulwich:{{revision}}
-  - name: path-context
-    value: packages/dulwich
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/dulwich/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -3968,14 +3422,14 @@ spec:
         "path": "./packages/dulwich",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: dulwich
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -3989,7 +3443,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/durationpy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: durationpy
@@ -4004,12 +3457,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/durationpy:{{revision}}
-  - name: path-context
-    value: packages/durationpy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/durationpy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4019,14 +3466,14 @@ spec:
         "path": "./packages/durationpy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: durationpy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4040,7 +3487,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/editables/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: editables
@@ -4055,12 +3501,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/editables:{{revision}}
-  - name: path-context
-    value: packages/editables
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/editables/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4070,14 +3510,14 @@ spec:
         "path": "./packages/editables",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: editables
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4091,7 +3531,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/elasticsearch/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: elasticsearch
@@ -4106,12 +3545,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/elasticsearch:{{revision}}
-  - name: path-context
-    value: packages/elasticsearch
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/elasticsearch/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4121,14 +3554,14 @@ spec:
         "path": "./packages/elasticsearch",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: elasticsearch
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4142,7 +3575,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/email-validator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: email-validator
@@ -4157,12 +3589,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/email-validator:{{revision}}
-  - name: path-context
-    value: packages/email-validator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/email-validator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4172,14 +3598,14 @@ spec:
         "path": "./packages/email-validator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: email-validator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4193,7 +3619,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/et-xmlfile/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: et-xmlfile
@@ -4208,12 +3633,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/et-xmlfile:{{revision}}
-  - name: path-context
-    value: packages/et-xmlfile
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/et-xmlfile/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4223,14 +3642,14 @@ spec:
         "path": "./packages/et-xmlfile",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: et-xmlfile
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4244,7 +3663,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/eventlet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: eventlet
@@ -4259,12 +3677,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/eventlet:{{revision}}
-  - name: path-context
-    value: packages/eventlet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/eventlet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4274,14 +3686,14 @@ spec:
         "path": "./packages/eventlet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: eventlet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4295,7 +3707,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/exceptiongroup/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: exceptiongroup
@@ -4310,12 +3721,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/exceptiongroup:{{revision}}
-  - name: path-context
-    value: packages/exceptiongroup
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/exceptiongroup/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4325,14 +3730,14 @@ spec:
         "path": "./packages/exceptiongroup",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: exceptiongroup
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4346,7 +3751,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/execnet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: execnet
@@ -4361,12 +3765,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/execnet:{{revision}}
-  - name: path-context
-    value: packages/execnet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/execnet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4376,14 +3774,14 @@ spec:
         "path": "./packages/execnet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: execnet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4397,7 +3795,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/executing/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: executing
@@ -4412,12 +3809,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/executing:{{revision}}
-  - name: path-context
-    value: packages/executing
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/executing/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4427,14 +3818,14 @@ spec:
         "path": "./packages/executing",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: executing
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4448,7 +3839,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/faker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: faker
@@ -4463,12 +3853,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/faker:{{revision}}
-  - name: path-context
-    value: packages/faker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/faker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4478,14 +3862,14 @@ spec:
         "path": "./packages/faker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: faker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4499,7 +3883,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fastapi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fastapi
@@ -4514,12 +3897,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/fastapi:{{revision}}
-  - name: path-context
-    value: packages/fastapi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fastapi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4529,14 +3906,14 @@ spec:
         "path": "./packages/fastapi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fastapi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4550,7 +3927,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fastavro/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fastavro
@@ -4565,12 +3941,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/fastavro:{{revision}}
-  - name: path-context
-    value: packages/fastavro
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fastavro/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4580,14 +3950,14 @@ spec:
         "path": "./packages/fastavro",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fastavro
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4601,7 +3971,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fastjsonschema/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fastjsonschema
@@ -4616,12 +3985,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/fastjsonschema:{{revision}}
-  - name: path-context
-    value: packages/fastjsonschema
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fastjsonschema/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4631,14 +3994,14 @@ spec:
         "path": "./packages/fastjsonschema",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fastjsonschema
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4652,7 +4015,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/filelock/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: filelock
@@ -4667,12 +4029,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/filelock:{{revision}}
-  - name: path-context
-    value: packages/filelock
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/filelock/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4682,14 +4038,14 @@ spec:
         "path": "./packages/filelock",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: filelock
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4703,7 +4059,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/findpython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: findpython
@@ -4718,12 +4073,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/findpython:{{revision}}
-  - name: path-context
-    value: packages/findpython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/findpython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4733,14 +4082,14 @@ spec:
         "path": "./packages/findpython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: findpython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4754,7 +4103,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/flake8/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: flake8
@@ -4769,12 +4117,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/flake8:{{revision}}
-  - name: path-context
-    value: packages/flake8
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/flake8/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4784,14 +4126,14 @@ spec:
         "path": "./packages/flake8",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: flake8
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4805,7 +4147,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/flatbuffers/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: flatbuffers
@@ -4820,12 +4161,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/flatbuffers:{{revision}}
-  - name: path-context
-    value: packages/flatbuffers
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/flatbuffers/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4835,14 +4170,14 @@ spec:
         "path": "./packages/flatbuffers",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: flatbuffers
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4856,7 +4191,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fonttools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fonttools
@@ -4871,12 +4205,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/fonttools:{{revision}}
-  - name: path-context
-    value: packages/fonttools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fonttools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4886,14 +4214,14 @@ spec:
         "path": "./packages/fonttools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fonttools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4907,7 +4235,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fqdn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fqdn
@@ -4922,12 +4249,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/fqdn:{{revision}}
-  - name: path-context
-    value: packages/fqdn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fqdn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4937,14 +4258,14 @@ spec:
         "path": "./packages/fqdn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fqdn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -4958,7 +4279,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/freezegun/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: freezegun
@@ -4973,12 +4293,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/freezegun:{{revision}}
-  - name: path-context
-    value: packages/freezegun
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/freezegun/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -4988,14 +4302,14 @@ spec:
         "path": "./packages/freezegun",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: freezegun
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5009,7 +4323,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/frozenlist/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: frozenlist
@@ -5024,12 +4337,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/frozenlist:{{revision}}
-  - name: path-context
-    value: packages/frozenlist
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/frozenlist/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5039,14 +4346,14 @@ spec:
         "path": "./packages/frozenlist",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: frozenlist
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5060,7 +4367,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/fsspec/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: fsspec
@@ -5075,12 +4381,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/fsspec:{{revision}}
-  - name: path-context
-    value: packages/fsspec
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/fsspec/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5090,14 +4390,14 @@ spec:
         "path": "./packages/fsspec",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: fsspec
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5111,7 +4411,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/future/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: future
@@ -5126,12 +4425,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/future:{{revision}}
-  - name: path-context
-    value: packages/future
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/future/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5141,14 +4434,14 @@ spec:
         "path": "./packages/future",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: future
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5162,7 +4455,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gcloud-aio-auth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gcloud-aio-auth
@@ -5177,12 +4469,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gcloud-aio-auth:{{revision}}
-  - name: path-context
-    value: packages/gcloud-aio-auth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gcloud-aio-auth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5192,14 +4478,14 @@ spec:
         "path": "./packages/gcloud-aio-auth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gcloud-aio-auth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5213,7 +4499,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gcloud-aio-bigquery/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gcloud-aio-bigquery
@@ -5228,12 +4513,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gcloud-aio-bigquery:{{revision}}
-  - name: path-context
-    value: packages/gcloud-aio-bigquery
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gcloud-aio-bigquery/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5243,14 +4522,14 @@ spec:
         "path": "./packages/gcloud-aio-bigquery",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gcloud-aio-bigquery
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5264,7 +4543,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gcsfs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gcsfs
@@ -5279,12 +4557,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gcsfs:{{revision}}
-  - name: path-context
-    value: packages/gcsfs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gcsfs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5294,14 +4566,14 @@ spec:
         "path": "./packages/gcsfs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gcsfs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5315,7 +4587,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gevent/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gevent
@@ -5330,12 +4601,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gevent:{{revision}}
-  - name: path-context
-    value: packages/gevent
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gevent/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5345,14 +4610,14 @@ spec:
         "path": "./packages/gevent",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gevent
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5366,7 +4631,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gitdb/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gitdb
@@ -5381,12 +4645,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gitdb:{{revision}}
-  - name: path-context
-    value: packages/gitdb
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gitdb/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5396,14 +4654,14 @@ spec:
         "path": "./packages/gitdb",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gitdb
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5417,7 +4675,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gitpython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gitpython
@@ -5432,12 +4689,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gitpython:{{revision}}
-  - name: path-context
-    value: packages/gitpython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gitpython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5447,14 +4698,14 @@ spec:
         "path": "./packages/gitpython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gitpython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5468,7 +4719,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-ads/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-ads
@@ -5483,12 +4733,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-ads:{{revision}}
-  - name: path-context
-    value: packages/google-ads
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-ads/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5498,14 +4742,14 @@ spec:
         "path": "./packages/google-ads",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-ads
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5519,7 +4763,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-api-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-api-core
@@ -5534,12 +4777,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-api-core:{{revision}}
-  - name: path-context
-    value: packages/google-api-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-api-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5549,14 +4786,14 @@ spec:
         "path": "./packages/google-api-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-api-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5570,7 +4807,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-api-python-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-api-python-client
@@ -5585,12 +4821,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-api-python-client:{{revision}}
-  - name: path-context
-    value: packages/google-api-python-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-api-python-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5600,14 +4830,14 @@ spec:
         "path": "./packages/google-api-python-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-api-python-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5621,7 +4851,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-auth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-auth
@@ -5636,12 +4865,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-auth:{{revision}}
-  - name: path-context
-    value: packages/google-auth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-auth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5651,14 +4874,14 @@ spec:
         "path": "./packages/google-auth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-auth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5672,7 +4895,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-auth-oauthlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-auth-oauthlib
@@ -5687,12 +4909,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-auth-oauthlib:{{revision}}
-  - name: path-context
-    value: packages/google-auth-oauthlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-auth-oauthlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5702,14 +4918,14 @@ spec:
         "path": "./packages/google-auth-oauthlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-auth-oauthlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5723,7 +4939,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-aiplatform/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-aiplatform
@@ -5738,12 +4953,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-aiplatform:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-aiplatform
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-aiplatform/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5753,14 +4962,14 @@ spec:
         "path": "./packages/google-cloud-aiplatform",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-aiplatform
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5774,7 +4983,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-audit-log/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-audit-log
@@ -5789,12 +4997,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-audit-log:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-audit-log
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-audit-log/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5804,14 +5006,14 @@ spec:
         "path": "./packages/google-cloud-audit-log",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-audit-log
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5825,7 +5027,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-bigquery/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-bigquery
@@ -5840,12 +5041,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-bigquery:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-bigquery
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-bigquery/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5855,14 +5050,14 @@ spec:
         "path": "./packages/google-cloud-bigquery",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-bigquery
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5876,7 +5071,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-bigquery-storage/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-bigquery-storage
@@ -5891,12 +5085,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-bigquery-storage:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-bigquery-storage
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-bigquery-storage/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5906,14 +5094,14 @@ spec:
         "path": "./packages/google-cloud-bigquery-storage",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-bigquery-storage
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5927,7 +5115,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-bigtable/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-bigtable
@@ -5942,12 +5129,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-bigtable:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-bigtable
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-bigtable/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -5957,14 +5138,14 @@ spec:
         "path": "./packages/google-cloud-bigtable",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-bigtable
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -5978,7 +5159,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-dataproc/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-dataproc
@@ -5993,12 +5173,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-dataproc:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-dataproc
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-dataproc/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6008,14 +5182,14 @@ spec:
         "path": "./packages/google-cloud-dataproc",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-dataproc
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6029,7 +5203,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-logging/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-logging
@@ -6044,12 +5217,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-logging:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-logging
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-logging/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6059,14 +5226,14 @@ spec:
         "path": "./packages/google-cloud-logging",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-logging
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6080,7 +5247,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-pubsub/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-pubsub
@@ -6095,12 +5261,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-pubsub:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-pubsub
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-pubsub/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6110,14 +5270,14 @@ spec:
         "path": "./packages/google-cloud-pubsub",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-pubsub
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6131,7 +5291,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-resource-manager/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-resource-manager
@@ -6146,12 +5305,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-resource-manager:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-resource-manager
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-resource-manager/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6161,14 +5314,14 @@ spec:
         "path": "./packages/google-cloud-resource-manager",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-resource-manager
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6182,7 +5335,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-secret-manager/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-secret-manager
@@ -6197,12 +5349,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-secret-manager:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-secret-manager
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-secret-manager/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6212,14 +5358,14 @@ spec:
         "path": "./packages/google-cloud-secret-manager",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-secret-manager
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6233,7 +5379,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-storage/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-storage
@@ -6248,12 +5393,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-storage:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-storage
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-storage/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6263,14 +5402,14 @@ spec:
         "path": "./packages/google-cloud-storage",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-storage
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6284,7 +5423,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-cloud-vision/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-cloud-vision
@@ -6299,12 +5437,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-cloud-vision:{{revision}}
-  - name: path-context
-    value: packages/google-cloud-vision
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-cloud-vision/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6314,14 +5446,14 @@ spec:
         "path": "./packages/google-cloud-vision",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-cloud-vision
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6335,7 +5467,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-crc32c/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-crc32c
@@ -6350,12 +5481,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-crc32c:{{revision}}
-  - name: path-context
-    value: packages/google-crc32c
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-crc32c/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6365,14 +5490,14 @@ spec:
         "path": "./packages/google-crc32c",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-crc32c
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6386,7 +5511,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/google-resumable-media/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: google-resumable-media
@@ -6401,12 +5525,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/google-resumable-media:{{revision}}
-  - name: path-context
-    value: packages/google-resumable-media
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/google-resumable-media/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6416,14 +5534,14 @@ spec:
         "path": "./packages/google-resumable-media",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: google-resumable-media
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6437,7 +5555,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/googleapis-common-protos/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: googleapis-common-protos
@@ -6452,12 +5569,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/googleapis-common-protos:{{revision}}
-  - name: path-context
-    value: packages/googleapis-common-protos
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/googleapis-common-protos/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6467,14 +5578,14 @@ spec:
         "path": "./packages/googleapis-common-protos",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: googleapis-common-protos
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6488,7 +5599,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/graphql-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: graphql-core
@@ -6503,12 +5613,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/graphql-core:{{revision}}
-  - name: path-context
-    value: packages/graphql-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/graphql-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6518,14 +5622,14 @@ spec:
         "path": "./packages/graphql-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: graphql-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6539,7 +5643,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/graphviz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: graphviz
@@ -6554,12 +5657,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/graphviz:{{revision}}
-  - name: path-context
-    value: packages/graphviz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/graphviz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6569,14 +5666,14 @@ spec:
         "path": "./packages/graphviz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: graphviz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6590,7 +5687,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/greenlet/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: greenlet
@@ -6605,12 +5701,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/greenlet:{{revision}}
-  - name: path-context
-    value: packages/greenlet
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/greenlet/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6620,14 +5710,14 @@ spec:
         "path": "./packages/greenlet",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: greenlet
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6641,7 +5731,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpc-google-iam-v1/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpc-google-iam-v1
@@ -6656,12 +5745,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/grpc-google-iam-v1:{{revision}}
-  - name: path-context
-    value: packages/grpc-google-iam-v1
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpc-google-iam-v1/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6671,14 +5754,14 @@ spec:
         "path": "./packages/grpc-google-iam-v1",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpc-google-iam-v1
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6692,7 +5775,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio
@@ -6707,12 +5789,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio:{{revision}}
-  - name: path-context
-    value: packages/grpcio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6722,14 +5798,14 @@ spec:
         "path": "./packages/grpcio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6743,7 +5819,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio-health-checking/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio-health-checking
@@ -6758,12 +5833,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio-health-checking:{{revision}}
-  - name: path-context
-    value: packages/grpcio-health-checking
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio-health-checking/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6773,14 +5842,14 @@ spec:
         "path": "./packages/grpcio-health-checking",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio-health-checking
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6794,7 +5863,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio-status/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio-status
@@ -6809,12 +5877,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio-status:{{revision}}
-  - name: path-context
-    value: packages/grpcio-status
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio-status/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6824,14 +5886,14 @@ spec:
         "path": "./packages/grpcio-status",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio-status
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6845,7 +5907,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/grpcio-tools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: grpcio-tools
@@ -6860,12 +5921,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/grpcio-tools:{{revision}}
-  - name: path-context
-    value: packages/grpcio-tools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/grpcio-tools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6875,14 +5930,14 @@ spec:
         "path": "./packages/grpcio-tools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: grpcio-tools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6896,7 +5951,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/gunicorn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: gunicorn
@@ -6911,12 +5965,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/gunicorn:{{revision}}
-  - name: path-context
-    value: packages/gunicorn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/gunicorn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6926,14 +5974,14 @@ spec:
         "path": "./packages/gunicorn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: gunicorn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6947,7 +5995,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/h11/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: h11
@@ -6962,12 +6009,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/h11:{{revision}}
-  - name: path-context
-    value: packages/h11
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/h11/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -6977,14 +6018,14 @@ spec:
         "path": "./packages/h11",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: h11
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -6998,7 +6039,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/h2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: h2
@@ -7013,12 +6053,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/h2:{{revision}}
-  - name: path-context
-    value: packages/h2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/h2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7028,14 +6062,14 @@ spec:
         "path": "./packages/h2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: h2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7049,7 +6083,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hatch-fancy-pypi-readme/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hatch-fancy-pypi-readme
@@ -7064,12 +6097,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/hatch-fancy-pypi-readme:{{revision}}
-  - name: path-context
-    value: packages/hatch-fancy-pypi-readme
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hatch-fancy-pypi-readme/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7079,14 +6106,14 @@ spec:
         "path": "./packages/hatch-fancy-pypi-readme",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hatch-fancy-pypi-readme
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7100,7 +6127,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hatch-vcs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hatch-vcs
@@ -7115,12 +6141,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/hatch-vcs:{{revision}}
-  - name: path-context
-    value: packages/hatch-vcs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hatch-vcs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7130,14 +6150,14 @@ spec:
         "path": "./packages/hatch-vcs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hatch-vcs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7151,7 +6171,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hatchling/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hatchling
@@ -7166,12 +6185,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/hatchling:{{revision}}
-  - name: path-context
-    value: packages/hatchling
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hatchling/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7181,14 +6194,14 @@ spec:
         "path": "./packages/hatchling",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hatchling
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7202,7 +6215,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hpack/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hpack
@@ -7217,12 +6229,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/hpack:{{revision}}
-  - name: path-context
-    value: packages/hpack
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hpack/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7232,14 +6238,14 @@ spec:
         "path": "./packages/hpack",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hpack
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7253,7 +6259,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httpcore/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httpcore
@@ -7268,12 +6273,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/httpcore:{{revision}}
-  - name: path-context
-    value: packages/httpcore
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httpcore/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7283,14 +6282,14 @@ spec:
         "path": "./packages/httpcore",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httpcore
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7304,7 +6303,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httplib2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httplib2
@@ -7319,12 +6317,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/httplib2:{{revision}}
-  - name: path-context
-    value: packages/httplib2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httplib2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7334,14 +6326,14 @@ spec:
         "path": "./packages/httplib2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httplib2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7355,7 +6347,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httptools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httptools
@@ -7370,12 +6361,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/httptools:{{revision}}
-  - name: path-context
-    value: packages/httptools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httptools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7385,14 +6370,14 @@ spec:
         "path": "./packages/httptools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httptools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7406,7 +6391,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/httpx/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: httpx
@@ -7421,12 +6405,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/httpx:{{revision}}
-  - name: path-context
-    value: packages/httpx
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/httpx/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7436,14 +6414,14 @@ spec:
         "path": "./packages/httpx",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: httpx
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7457,7 +6435,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/humanfriendly/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: humanfriendly
@@ -7472,12 +6449,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/humanfriendly:{{revision}}
-  - name: path-context
-    value: packages/humanfriendly
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/humanfriendly/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7487,14 +6458,14 @@ spec:
         "path": "./packages/humanfriendly",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: humanfriendly
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7508,7 +6479,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/humanize/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: humanize
@@ -7523,12 +6493,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/humanize:{{revision}}
-  - name: path-context
-    value: packages/humanize
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/humanize/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7538,14 +6502,14 @@ spec:
         "path": "./packages/humanize",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: humanize
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7559,7 +6523,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hvac/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hvac
@@ -7574,12 +6537,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/hvac:{{revision}}
-  - name: path-context
-    value: packages/hvac
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hvac/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7589,14 +6546,14 @@ spec:
         "path": "./packages/hvac",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hvac
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7610,7 +6567,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/hyperframe/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: hyperframe
@@ -7625,12 +6581,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/hyperframe:{{revision}}
-  - name: path-context
-    value: packages/hyperframe
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/hyperframe/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7640,14 +6590,14 @@ spec:
         "path": "./packages/hyperframe",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: hyperframe
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7661,7 +6611,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/identify/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: identify
@@ -7676,12 +6625,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/identify:{{revision}}
-  - name: path-context
-    value: packages/identify
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/identify/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7691,14 +6634,14 @@ spec:
         "path": "./packages/identify",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: identify
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7712,7 +6655,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/idna/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: idna
@@ -7727,12 +6669,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/idna:{{revision}}
-  - name: path-context
-    value: packages/idna
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/idna/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7742,14 +6678,14 @@ spec:
         "path": "./packages/idna",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: idna
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7763,7 +6699,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/imageio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: imageio
@@ -7778,12 +6713,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/imageio:{{revision}}
-  - name: path-context
-    value: packages/imageio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/imageio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7793,14 +6722,14 @@ spec:
         "path": "./packages/imageio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: imageio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7814,7 +6743,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/importlib-metadata/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: importlib-metadata
@@ -7829,12 +6757,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/importlib-metadata:{{revision}}
-  - name: path-context
-    value: packages/importlib-metadata
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/importlib-metadata/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7844,14 +6766,14 @@ spec:
         "path": "./packages/importlib-metadata",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: importlib-metadata
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7865,7 +6787,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/importlib-resources/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: importlib-resources
@@ -7880,12 +6801,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/importlib-resources:{{revision}}
-  - name: path-context
-    value: packages/importlib-resources
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/importlib-resources/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7895,14 +6810,14 @@ spec:
         "path": "./packages/importlib-resources",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: importlib-resources
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7916,7 +6831,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/inflection/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: inflection
@@ -7931,12 +6845,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/inflection:{{revision}}
-  - name: path-context
-    value: packages/inflection
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/inflection/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7946,14 +6854,14 @@ spec:
         "path": "./packages/inflection",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: inflection
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -7967,7 +6875,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/iniconfig/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: iniconfig
@@ -7982,12 +6889,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/iniconfig:{{revision}}
-  - name: path-context
-    value: packages/iniconfig
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/iniconfig/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -7997,14 +6898,14 @@ spec:
         "path": "./packages/iniconfig",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: iniconfig
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8018,7 +6919,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/installer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: installer
@@ -8033,12 +6933,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/installer:{{revision}}
-  - name: path-context
-    value: packages/installer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/installer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8048,14 +6942,14 @@ spec:
         "path": "./packages/installer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: installer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8069,7 +6963,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ipython/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ipython
@@ -8084,12 +6977,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/ipython:{{revision}}
-  - name: path-context
-    value: packages/ipython
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ipython/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8099,14 +6986,14 @@ spec:
         "path": "./packages/ipython",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ipython
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8120,7 +7007,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/isodate/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: isodate
@@ -8135,12 +7021,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/isodate:{{revision}}
-  - name: path-context
-    value: packages/isodate
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/isodate/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8150,14 +7030,14 @@ spec:
         "path": "./packages/isodate",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: isodate
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8171,7 +7051,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/isoduration/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: isoduration
@@ -8186,12 +7065,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/isoduration:{{revision}}
-  - name: path-context
-    value: packages/isoduration
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/isoduration/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8201,14 +7074,14 @@ spec:
         "path": "./packages/isoduration",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: isoduration
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8222,7 +7095,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/isort/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: isort
@@ -8237,12 +7109,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/isort:{{revision}}
-  - name: path-context
-    value: packages/isort
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/isort/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8252,14 +7118,14 @@ spec:
         "path": "./packages/isort",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: isort
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8273,7 +7139,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/itsdangerous/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: itsdangerous
@@ -8288,12 +7153,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/itsdangerous:{{revision}}
-  - name: path-context
-    value: packages/itsdangerous
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/itsdangerous/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8303,14 +7162,14 @@ spec:
         "path": "./packages/itsdangerous",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: itsdangerous
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8324,7 +7183,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jaraco-context/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jaraco-context
@@ -8339,12 +7197,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jaraco-context:{{revision}}
-  - name: path-context
-    value: packages/jaraco-context
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jaraco-context/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8354,14 +7206,14 @@ spec:
         "path": "./packages/jaraco-context",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jaraco-context
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8375,7 +7227,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jaraco-functools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jaraco-functools
@@ -8390,12 +7241,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jaraco-functools:{{revision}}
-  - name: path-context
-    value: packages/jaraco-functools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jaraco-functools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8405,14 +7250,14 @@ spec:
         "path": "./packages/jaraco-functools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jaraco-functools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8426,7 +7271,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jedi/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jedi
@@ -8441,12 +7285,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jedi:{{revision}}
-  - name: path-context
-    value: packages/jedi
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jedi/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8456,14 +7294,14 @@ spec:
         "path": "./packages/jedi",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jedi
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8477,7 +7315,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jeepney/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jeepney
@@ -8492,12 +7329,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jeepney:{{revision}}
-  - name: path-context
-    value: packages/jeepney
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jeepney/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8507,14 +7338,14 @@ spec:
         "path": "./packages/jeepney",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jeepney
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8528,7 +7359,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jinja2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jinja2
@@ -8543,12 +7373,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jinja2:{{revision}}
-  - name: path-context
-    value: packages/jinja2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jinja2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8558,14 +7382,14 @@ spec:
         "path": "./packages/jinja2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jinja2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8579,7 +7403,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jmespath/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jmespath
@@ -8594,12 +7417,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jmespath:{{revision}}
-  - name: path-context
-    value: packages/jmespath
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jmespath/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8609,14 +7426,14 @@ spec:
         "path": "./packages/jmespath",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jmespath
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8630,7 +7447,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/joblib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: joblib
@@ -8645,12 +7461,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/joblib:{{revision}}
-  - name: path-context
-    value: packages/joblib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/joblib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8660,14 +7470,14 @@ spec:
         "path": "./packages/joblib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: joblib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8681,7 +7491,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/json5/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: json5
@@ -8696,12 +7505,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/json5:{{revision}}
-  - name: path-context
-    value: packages/json5
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/json5/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8711,14 +7514,14 @@ spec:
         "path": "./packages/json5",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: json5
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8732,7 +7535,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jsonpatch/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jsonpatch
@@ -8747,12 +7549,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jsonpatch:{{revision}}
-  - name: path-context
-    value: packages/jsonpatch
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jsonpatch/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8762,14 +7558,14 @@ spec:
         "path": "./packages/jsonpatch",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jsonpatch
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8783,7 +7579,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jsonpointer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jsonpointer
@@ -8798,12 +7593,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jsonpointer:{{revision}}
-  - name: path-context
-    value: packages/jsonpointer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jsonpointer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8813,14 +7602,14 @@ spec:
         "path": "./packages/jsonpointer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jsonpointer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8834,7 +7623,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jupyter-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jupyter-client
@@ -8849,12 +7637,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jupyter-client:{{revision}}
-  - name: path-context
-    value: packages/jupyter-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jupyter-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8864,14 +7646,14 @@ spec:
         "path": "./packages/jupyter-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jupyter-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8885,7 +7667,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/jupyter-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: jupyter-core
@@ -8900,12 +7681,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/jupyter-core:{{revision}}
-  - name: path-context
-    value: packages/jupyter-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/jupyter-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8915,14 +7690,14 @@ spec:
         "path": "./packages/jupyter-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: jupyter-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8936,7 +7711,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/keras/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: keras
@@ -8951,12 +7725,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/keras:{{revision}}
-  - name: path-context
-    value: packages/keras
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/keras/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -8966,14 +7734,14 @@ spec:
         "path": "./packages/keras",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: keras
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -8987,7 +7755,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/keyring/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: keyring
@@ -9002,12 +7769,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/keyring:{{revision}}
-  - name: path-context
-    value: packages/keyring
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/keyring/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9017,14 +7778,14 @@ spec:
         "path": "./packages/keyring",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: keyring
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9038,7 +7799,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/kiwisolver/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: kiwisolver
@@ -9053,12 +7813,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/kiwisolver:{{revision}}
-  - name: path-context
-    value: packages/kiwisolver
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/kiwisolver/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9068,14 +7822,14 @@ spec:
         "path": "./packages/kiwisolver",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: kiwisolver
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9089,7 +7843,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/langchain/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: langchain
@@ -9104,12 +7857,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/langchain:{{revision}}
-  - name: path-context
-    value: packages/langchain
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/langchain/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9119,14 +7866,14 @@ spec:
         "path": "./packages/langchain",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: langchain
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9140,7 +7887,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/langchain-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: langchain-core
@@ -9155,12 +7901,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/langchain-core:{{revision}}
-  - name: path-context
-    value: packages/langchain-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/langchain-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9170,14 +7910,14 @@ spec:
         "path": "./packages/langchain-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: langchain-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9191,7 +7931,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/langsmith/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: langsmith
@@ -9206,12 +7945,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/langsmith:{{revision}}
-  - name: path-context
-    value: packages/langsmith
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/langsmith/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9221,14 +7954,14 @@ spec:
         "path": "./packages/langsmith",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: langsmith
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9242,7 +7975,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/lazy-object-proxy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: lazy-object-proxy
@@ -9257,12 +7989,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/lazy-object-proxy:{{revision}}
-  - name: path-context
-    value: packages/lazy-object-proxy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/lazy-object-proxy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9272,14 +7998,14 @@ spec:
         "path": "./packages/lazy-object-proxy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: lazy-object-proxy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9293,7 +8019,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/limits/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: limits
@@ -9308,12 +8033,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/limits:{{revision}}
-  - name: path-context
-    value: packages/limits
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/limits/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9323,14 +8042,14 @@ spec:
         "path": "./packages/limits",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: limits
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9344,7 +8063,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/loguru/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: loguru
@@ -9359,12 +8077,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/loguru:{{revision}}
-  - name: path-context
-    value: packages/loguru
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/loguru/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9374,14 +8086,14 @@ spec:
         "path": "./packages/loguru",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: loguru
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9395,7 +8107,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/lxml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: lxml
@@ -9410,12 +8121,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/lxml:{{revision}}
-  - name: path-context
-    value: packages/lxml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/lxml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9425,14 +8130,14 @@ spec:
         "path": "./packages/lxml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: lxml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9446,7 +8151,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/lz4/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: lz4
@@ -9461,12 +8165,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/lz4:{{revision}}
-  - name: path-context
-    value: packages/lz4
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/lz4/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9476,14 +8174,14 @@ spec:
         "path": "./packages/lz4",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: lz4
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9497,7 +8195,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mako/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mako
@@ -9512,12 +8209,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mako:{{revision}}
-  - name: path-context
-    value: packages/mako
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mako/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9527,14 +8218,14 @@ spec:
         "path": "./packages/mako",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mako
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9548,7 +8239,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/markdown/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: markdown
@@ -9563,12 +8253,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/markdown:{{revision}}
-  - name: path-context
-    value: packages/markdown
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/markdown/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9578,14 +8262,14 @@ spec:
         "path": "./packages/markdown",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: markdown
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9599,7 +8283,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/markdown-it-py/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: markdown-it-py
@@ -9614,12 +8297,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/markdown-it-py:{{revision}}
-  - name: path-context
-    value: packages/markdown-it-py
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/markdown-it-py/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9629,14 +8306,14 @@ spec:
         "path": "./packages/markdown-it-py",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: markdown-it-py
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9650,7 +8327,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/markupsafe/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: markupsafe
@@ -9665,12 +8341,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/markupsafe:{{revision}}
-  - name: path-context
-    value: packages/markupsafe
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/markupsafe/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9680,14 +8350,14 @@ spec:
         "path": "./packages/markupsafe",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: markupsafe
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9701,7 +8371,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/marshmallow/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: marshmallow
@@ -9716,12 +8385,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/marshmallow:{{revision}}
-  - name: path-context
-    value: packages/marshmallow
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/marshmallow/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9731,14 +8394,14 @@ spec:
         "path": "./packages/marshmallow",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: marshmallow
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9752,7 +8415,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/matplotlib-inline/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: matplotlib-inline
@@ -9767,12 +8429,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/matplotlib-inline:{{revision}}
-  - name: path-context
-    value: packages/matplotlib-inline
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/matplotlib-inline/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9782,14 +8438,14 @@ spec:
         "path": "./packages/matplotlib-inline",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: matplotlib-inline
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9803,7 +8459,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mccabe/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mccabe
@@ -9818,12 +8473,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mccabe:{{revision}}
-  - name: path-context
-    value: packages/mccabe
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mccabe/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9833,14 +8482,14 @@ spec:
         "path": "./packages/mccabe",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mccabe
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9854,7 +8503,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mdurl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mdurl
@@ -9869,12 +8517,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mdurl:{{revision}}
-  - name: path-context
-    value: packages/mdurl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mdurl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9884,14 +8526,14 @@ spec:
         "path": "./packages/mdurl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mdurl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9905,7 +8547,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/meson-python/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: meson-python
@@ -9920,12 +8561,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/meson-python:{{revision}}
-  - name: path-context
-    value: packages/meson-python
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/meson-python/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9935,14 +8570,14 @@ spec:
         "path": "./packages/meson-python",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: meson-python
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -9956,7 +8591,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/microsoft-kiota-http/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: microsoft-kiota-http
@@ -9971,12 +8605,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/microsoft-kiota-http:{{revision}}
-  - name: path-context
-    value: packages/microsoft-kiota-http
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/microsoft-kiota-http/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -9986,14 +8614,14 @@ spec:
         "path": "./packages/microsoft-kiota-http",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: microsoft-kiota-http
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10007,7 +8635,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mistune/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mistune
@@ -10022,12 +8649,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mistune:{{revision}}
-  - name: path-context
-    value: packages/mistune
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mistune/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10037,14 +8658,14 @@ spec:
         "path": "./packages/mistune",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mistune
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10058,7 +8679,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mock/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mock
@@ -10073,12 +8693,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mock:{{revision}}
-  - name: path-context
-    value: packages/mock
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mock/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10088,14 +8702,14 @@ spec:
         "path": "./packages/mock",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mock
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10109,7 +8723,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/more-itertools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: more-itertools
@@ -10124,12 +8737,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/more-itertools:{{revision}}
-  - name: path-context
-    value: packages/more-itertools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/more-itertools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10139,14 +8746,14 @@ spec:
         "path": "./packages/more-itertools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: more-itertools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10160,7 +8767,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mpmath/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mpmath
@@ -10175,12 +8781,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mpmath:{{revision}}
-  - name: path-context
-    value: packages/mpmath
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mpmath/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10190,14 +8790,14 @@ spec:
         "path": "./packages/mpmath",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mpmath
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10211,7 +8811,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/msal/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: msal
@@ -10226,12 +8825,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/msal:{{revision}}
-  - name: path-context
-    value: packages/msal
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/msal/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10241,14 +8834,14 @@ spec:
         "path": "./packages/msal",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: msal
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10262,7 +8855,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/msal-extensions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: msal-extensions
@@ -10277,12 +8869,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/msal-extensions:{{revision}}
-  - name: path-context
-    value: packages/msal-extensions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/msal-extensions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10292,14 +8878,14 @@ spec:
         "path": "./packages/msal-extensions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: msal-extensions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10313,7 +8899,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/msgpack/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: msgpack
@@ -10328,12 +8913,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/msgpack:{{revision}}
-  - name: path-context
-    value: packages/msgpack
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/msgpack/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10343,14 +8922,14 @@ spec:
         "path": "./packages/msgpack",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: msgpack
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10364,7 +8943,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/multidict/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: multidict
@@ -10379,12 +8957,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/multidict:{{revision}}
-  - name: path-context
-    value: packages/multidict
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/multidict/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10394,14 +8966,14 @@ spec:
         "path": "./packages/multidict",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: multidict
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10415,7 +8987,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/multiprocess/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: multiprocess
@@ -10430,12 +9001,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/multiprocess:{{revision}}
-  - name: path-context
-    value: packages/multiprocess
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/multiprocess/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10445,14 +9010,14 @@ spec:
         "path": "./packages/multiprocess",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: multiprocess
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10466,7 +9031,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mypy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mypy
@@ -10481,12 +9045,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mypy:{{revision}}
-  - name: path-context
-    value: packages/mypy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mypy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10496,14 +9054,14 @@ spec:
         "path": "./packages/mypy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mypy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10517,7 +9075,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/mypy-extensions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: mypy-extensions
@@ -10532,12 +9089,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/mypy-extensions:{{revision}}
-  - name: path-context
-    value: packages/mypy-extensions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/mypy-extensions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10547,14 +9098,14 @@ spec:
         "path": "./packages/mypy-extensions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: mypy-extensions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10568,7 +9119,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/narwhals/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: narwhals
@@ -10583,12 +9133,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/narwhals:{{revision}}
-  - name: path-context
-    value: packages/narwhals
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/narwhals/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10598,14 +9142,14 @@ spec:
         "path": "./packages/narwhals",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: narwhals
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10619,7 +9163,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/nest-asyncio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: nest-asyncio
@@ -10634,12 +9177,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/nest-asyncio:{{revision}}
-  - name: path-context
-    value: packages/nest-asyncio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/nest-asyncio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10649,14 +9186,14 @@ spec:
         "path": "./packages/nest-asyncio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: nest-asyncio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10670,7 +9207,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/networkx/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: networkx
@@ -10685,12 +9221,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/networkx:{{revision}}
-  - name: path-context
-    value: packages/networkx
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/networkx/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10700,14 +9230,14 @@ spec:
         "path": "./packages/networkx",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: networkx
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10721,7 +9251,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ninja/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ninja
@@ -10736,12 +9265,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/ninja:{{revision}}
-  - name: path-context
-    value: packages/ninja
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ninja/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10751,14 +9274,14 @@ spec:
         "path": "./packages/ninja",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ninja
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10772,7 +9295,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/nltk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: nltk
@@ -10787,12 +9309,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/nltk:{{revision}}
-  - name: path-context
-    value: packages/nltk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/nltk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10802,14 +9318,14 @@ spec:
         "path": "./packages/nltk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: nltk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10823,7 +9339,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/nodeenv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: nodeenv
@@ -10838,12 +9353,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/nodeenv:{{revision}}
-  - name: path-context
-    value: packages/nodeenv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/nodeenv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10853,14 +9362,14 @@ spec:
         "path": "./packages/nodeenv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: nodeenv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10874,7 +9383,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/numpy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: numpy
@@ -10889,12 +9397,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/numpy:{{revision}}
-  - name: path-context
-    value: packages/numpy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/numpy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10904,14 +9406,14 @@ spec:
         "path": "./packages/numpy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: numpy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10925,7 +9427,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/oauth2client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: oauth2client
@@ -10940,12 +9441,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/oauth2client:{{revision}}
-  - name: path-context
-    value: packages/oauth2client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/oauth2client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -10955,14 +9450,14 @@ spec:
         "path": "./packages/oauth2client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: oauth2client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -10976,7 +9471,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/oauthlib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: oauthlib
@@ -10991,12 +9485,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/oauthlib:{{revision}}
-  - name: path-context
-    value: packages/oauthlib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/oauthlib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11006,14 +9494,14 @@ spec:
         "path": "./packages/oauthlib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: oauthlib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11027,7 +9515,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/openpyxl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: openpyxl
@@ -11042,12 +9529,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/openpyxl:{{revision}}
-  - name: path-context
-    value: packages/openpyxl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/openpyxl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11057,14 +9538,14 @@ spec:
         "path": "./packages/openpyxl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: openpyxl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11078,7 +9559,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-exporter-otlp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-exporter-otlp
@@ -11093,12 +9573,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-exporter-otlp:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-exporter-otlp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-exporter-otlp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11108,14 +9582,14 @@ spec:
         "path": "./packages/opentelemetry-exporter-otlp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-exporter-otlp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11129,7 +9603,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-exporter-prometheus/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-exporter-prometheus
@@ -11144,12 +9617,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-exporter-prometheus:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-exporter-prometheus
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-exporter-prometheus/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11159,14 +9626,14 @@ spec:
         "path": "./packages/opentelemetry-exporter-prometheus",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-exporter-prometheus
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11180,7 +9647,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-instrumentation/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-instrumentation
@@ -11195,12 +9661,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-instrumentation:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-instrumentation
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-instrumentation/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11210,14 +9670,14 @@ spec:
         "path": "./packages/opentelemetry-instrumentation",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-instrumentation
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11231,7 +9691,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-instrumentation-requests/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-instrumentation-requests
@@ -11246,12 +9705,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-instrumentation-requests:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-instrumentation-requests
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-instrumentation-requests/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11261,14 +9714,14 @@ spec:
         "path": "./packages/opentelemetry-instrumentation-requests",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-instrumentation-requests
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11282,7 +9735,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-proto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-proto
@@ -11297,12 +9749,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-proto:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-proto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-proto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11312,14 +9758,14 @@ spec:
         "path": "./packages/opentelemetry-proto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-proto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11333,7 +9779,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-sdk
@@ -11348,12 +9793,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-sdk:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11363,14 +9802,14 @@ spec:
         "path": "./packages/opentelemetry-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11384,7 +9823,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-semantic-conventions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-semantic-conventions
@@ -11399,12 +9837,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-semantic-conventions:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-semantic-conventions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-semantic-conventions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11414,14 +9846,14 @@ spec:
         "path": "./packages/opentelemetry-semantic-conventions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-semantic-conventions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11435,7 +9867,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/opentelemetry-util-http/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: opentelemetry-util-http
@@ -11450,12 +9881,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/opentelemetry-util-http:{{revision}}
-  - name: path-context
-    value: packages/opentelemetry-util-http
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/opentelemetry-util-http/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11465,14 +9890,14 @@ spec:
         "path": "./packages/opentelemetry-util-http",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: opentelemetry-util-http
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11486,7 +9911,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/oscrypto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: oscrypto
@@ -11501,12 +9925,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/oscrypto:{{revision}}
-  - name: path-context
-    value: packages/oscrypto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/oscrypto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11516,14 +9934,14 @@ spec:
         "path": "./packages/oscrypto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: oscrypto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11537,7 +9955,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/overrides/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: overrides
@@ -11552,12 +9969,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/overrides:{{revision}}
-  - name: path-context
-    value: packages/overrides
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/overrides/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11567,14 +9978,14 @@ spec:
         "path": "./packages/overrides",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: overrides
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11588,7 +9999,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/packaging/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: packaging
@@ -11603,12 +10013,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/packaging:{{revision}}
-  - name: path-context
-    value: packages/packaging
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/packaging/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11618,14 +10022,14 @@ spec:
         "path": "./packages/packaging",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: packaging
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11639,7 +10043,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pandas/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pandas
@@ -11654,12 +10057,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pandas:{{revision}}
-  - name: path-context
-    value: packages/pandas
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pandas/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11669,14 +10066,14 @@ spec:
         "path": "./packages/pandas",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pandas
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11690,7 +10087,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pandas-gbq/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pandas-gbq
@@ -11705,12 +10101,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pandas-gbq:{{revision}}
-  - name: path-context
-    value: packages/pandas-gbq
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pandas-gbq/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11720,14 +10110,14 @@ spec:
         "path": "./packages/pandas-gbq",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pandas-gbq
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11741,7 +10131,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pandocfilters/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pandocfilters
@@ -11756,12 +10145,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pandocfilters:{{revision}}
-  - name: path-context
-    value: packages/pandocfilters
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pandocfilters/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11771,14 +10154,14 @@ spec:
         "path": "./packages/pandocfilters",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pandocfilters
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11792,7 +10175,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/paramiko/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: paramiko
@@ -11807,12 +10189,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/paramiko:{{revision}}
-  - name: path-context
-    value: packages/paramiko
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/paramiko/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11822,14 +10198,14 @@ spec:
         "path": "./packages/paramiko",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: paramiko
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11843,7 +10219,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/parso/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: parso
@@ -11858,12 +10233,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/parso:{{revision}}
-  - name: path-context
-    value: packages/parso
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/parso/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11873,14 +10242,14 @@ spec:
         "path": "./packages/parso",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: parso
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11894,7 +10263,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/patchelf/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: patchelf
@@ -11909,12 +10277,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/patchelf:{{revision}}
-  - name: path-context
-    value: packages/patchelf
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/patchelf/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11924,14 +10286,14 @@ spec:
         "path": "./packages/patchelf",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: patchelf
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11945,7 +10307,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pathspec/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pathspec
@@ -11960,12 +10321,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pathspec:{{revision}}
-  - name: path-context
-    value: packages/pathspec
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pathspec/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -11975,14 +10330,14 @@ spec:
         "path": "./packages/pathspec",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pathspec
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -11996,7 +10351,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pbr/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pbr
@@ -12011,12 +10365,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pbr:{{revision}}
-  - name: path-context
-    value: packages/pbr
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pbr/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12026,14 +10374,14 @@ spec:
         "path": "./packages/pbr",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pbr
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12047,7 +10395,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pexpect/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pexpect
@@ -12062,12 +10409,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pexpect:{{revision}}
-  - name: path-context
-    value: packages/pexpect
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pexpect/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12077,14 +10418,14 @@ spec:
         "path": "./packages/pexpect",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pexpect
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12098,7 +10439,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pg8000/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pg8000
@@ -12113,12 +10453,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pg8000:{{revision}}
-  - name: path-context
-    value: packages/pg8000
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pg8000/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12128,14 +10462,14 @@ spec:
         "path": "./packages/pg8000",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pg8000
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12149,7 +10483,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pillow/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pillow
@@ -12164,12 +10497,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pillow:{{revision}}
-  - name: path-context
-    value: packages/pillow
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pillow/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12179,14 +10506,14 @@ spec:
         "path": "./packages/pillow",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pillow
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12200,7 +10527,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pinotdb/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pinotdb
@@ -12215,12 +10541,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pinotdb:{{revision}}
-  - name: path-context
-    value: packages/pinotdb
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pinotdb/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12230,14 +10550,14 @@ spec:
         "path": "./packages/pinotdb",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pinotdb
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12251,7 +10571,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pip/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pip
@@ -12266,12 +10585,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pip:{{revision}}
-  - name: path-context
-    value: packages/pip
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pip/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12281,14 +10594,14 @@ spec:
         "path": "./packages/pip",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pip
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12302,7 +10615,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pkginfo/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pkginfo
@@ -12317,12 +10629,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pkginfo:{{revision}}
-  - name: path-context
-    value: packages/pkginfo
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pkginfo/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12332,14 +10638,14 @@ spec:
         "path": "./packages/pkginfo",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pkginfo
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12353,7 +10659,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pkgutil-resolve-name/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pkgutil-resolve-name
@@ -12368,12 +10673,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pkgutil-resolve-name:{{revision}}
-  - name: path-context
-    value: packages/pkgutil-resolve-name
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pkgutil-resolve-name/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12383,14 +10682,14 @@ spec:
         "path": "./packages/pkgutil-resolve-name",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pkgutil-resolve-name
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12404,7 +10703,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/platformdirs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: platformdirs
@@ -12419,12 +10717,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/platformdirs:{{revision}}
-  - name: path-context
-    value: packages/platformdirs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/platformdirs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12434,14 +10726,14 @@ spec:
         "path": "./packages/platformdirs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: platformdirs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12455,7 +10747,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pluggy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pluggy
@@ -12470,12 +10761,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pluggy:{{revision}}
-  - name: path-context
-    value: packages/pluggy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pluggy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12485,14 +10770,14 @@ spec:
         "path": "./packages/pluggy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pluggy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12506,7 +10791,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ply/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ply
@@ -12521,12 +10805,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/ply:{{revision}}
-  - name: path-context
-    value: packages/ply
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ply/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12536,14 +10814,14 @@ spec:
         "path": "./packages/ply",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ply
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12557,7 +10835,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/poetry-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: poetry-core
@@ -12572,12 +10849,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/poetry-core:{{revision}}
-  - name: path-context
-    value: packages/poetry-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/poetry-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12587,14 +10858,14 @@ spec:
         "path": "./packages/poetry-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: poetry-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12608,7 +10879,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/poetry-plugin-export/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: poetry-plugin-export
@@ -12623,12 +10893,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/poetry-plugin-export:{{revision}}
-  - name: path-context
-    value: packages/poetry-plugin-export
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/poetry-plugin-export/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12638,14 +10902,14 @@ spec:
         "path": "./packages/poetry-plugin-export",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: poetry-plugin-export
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12659,7 +10923,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/portalocker/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: portalocker
@@ -12674,12 +10937,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/portalocker:{{revision}}
-  - name: path-context
-    value: packages/portalocker
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/portalocker/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12689,14 +10946,14 @@ spec:
         "path": "./packages/portalocker",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: portalocker
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12710,7 +10967,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pre-commit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pre-commit
@@ -12725,12 +10981,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pre-commit:{{revision}}
-  - name: path-context
-    value: packages/pre-commit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pre-commit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12740,14 +10990,14 @@ spec:
         "path": "./packages/pre-commit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pre-commit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12761,7 +11011,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/prometheus-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: prometheus-client
@@ -12776,12 +11025,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/prometheus-client:{{revision}}
-  - name: path-context
-    value: packages/prometheus-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/prometheus-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12791,14 +11034,14 @@ spec:
         "path": "./packages/prometheus-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: prometheus-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12812,7 +11055,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/prompt-toolkit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: prompt-toolkit
@@ -12827,12 +11069,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/prompt-toolkit:{{revision}}
-  - name: path-context
-    value: packages/prompt-toolkit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/prompt-toolkit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12842,14 +11078,14 @@ spec:
         "path": "./packages/prompt-toolkit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: prompt-toolkit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12863,7 +11099,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/propcache/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: propcache
@@ -12878,12 +11113,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/propcache:{{revision}}
-  - name: path-context
-    value: packages/propcache
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/propcache/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12893,14 +11122,14 @@ spec:
         "path": "./packages/propcache",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: propcache
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12914,7 +11143,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/proto-plus/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: proto-plus
@@ -12929,12 +11157,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/proto-plus:{{revision}}
-  - name: path-context
-    value: packages/proto-plus
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/proto-plus/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12944,14 +11166,14 @@ spec:
         "path": "./packages/proto-plus",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: proto-plus
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -12965,7 +11187,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/protobuf/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: protobuf
@@ -12980,12 +11201,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/protobuf:{{revision}}
-  - name: path-context
-    value: packages/protobuf
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/protobuf/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -12995,14 +11210,14 @@ spec:
         "path": "./packages/protobuf",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: protobuf
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13016,7 +11231,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/psutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: psutil
@@ -13031,12 +11245,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/psutil:{{revision}}
-  - name: path-context
-    value: packages/psutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/psutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13046,14 +11254,14 @@ spec:
         "path": "./packages/psutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: psutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13067,7 +11275,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/ptyprocess/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: ptyprocess
@@ -13082,12 +11289,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/ptyprocess:{{revision}}
-  - name: path-context
-    value: packages/ptyprocess
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/ptyprocess/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13097,14 +11298,14 @@ spec:
         "path": "./packages/ptyprocess",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: ptyprocess
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13118,7 +11319,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pure-eval/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pure-eval
@@ -13133,12 +11333,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pure-eval:{{revision}}
-  - name: path-context
-    value: packages/pure-eval
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pure-eval/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13148,14 +11342,14 @@ spec:
         "path": "./packages/pure-eval",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pure-eval
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13169,7 +11363,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/py/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: py
@@ -13184,12 +11377,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/py:{{revision}}
-  - name: path-context
-    value: packages/py
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/py/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13199,14 +11386,14 @@ spec:
         "path": "./packages/py",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: py
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13220,7 +11407,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/py4j/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: py4j
@@ -13235,12 +11421,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/py4j:{{revision}}
-  - name: path-context
-    value: packages/py4j
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/py4j/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13250,14 +11430,14 @@ spec:
         "path": "./packages/py4j",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: py4j
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13271,7 +11451,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyasn1/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyasn1
@@ -13286,12 +11465,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyasn1:{{revision}}
-  - name: path-context
-    value: packages/pyasn1
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyasn1/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13301,14 +11474,14 @@ spec:
         "path": "./packages/pyasn1",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyasn1
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13322,7 +11495,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyasn1-modules/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyasn1-modules
@@ -13337,12 +11509,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyasn1-modules:{{revision}}
-  - name: path-context
-    value: packages/pyasn1-modules
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyasn1-modules/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13352,14 +11518,14 @@ spec:
         "path": "./packages/pyasn1-modules",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyasn1-modules
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13373,7 +11539,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pycodestyle/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pycodestyle
@@ -13388,12 +11553,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pycodestyle:{{revision}}
-  - name: path-context
-    value: packages/pycodestyle
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pycodestyle/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13403,14 +11562,14 @@ spec:
         "path": "./packages/pycodestyle",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pycodestyle
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13424,7 +11583,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pycparser/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pycparser
@@ -13439,12 +11597,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pycparser:{{revision}}
-  - name: path-context
-    value: packages/pycparser
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pycparser/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13454,14 +11606,14 @@ spec:
         "path": "./packages/pycparser",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pycparser
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13475,7 +11627,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pycryptodomex/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pycryptodomex
@@ -13490,12 +11641,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pycryptodomex:{{revision}}
-  - name: path-context
-    value: packages/pycryptodomex
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pycryptodomex/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13505,14 +11650,14 @@ spec:
         "path": "./packages/pycryptodomex",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pycryptodomex
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13526,7 +11671,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pydantic/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pydantic
@@ -13541,12 +11685,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pydantic:{{revision}}
-  - name: path-context
-    value: packages/pydantic
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pydantic/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13556,14 +11694,14 @@ spec:
         "path": "./packages/pydantic",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pydantic
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13577,7 +11715,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pydantic-settings/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pydantic-settings
@@ -13592,12 +11729,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pydantic-settings:{{revision}}
-  - name: path-context
-    value: packages/pydantic-settings
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pydantic-settings/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13607,14 +11738,14 @@ spec:
         "path": "./packages/pydantic-settings",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pydantic-settings
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13628,7 +11759,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyflakes/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyflakes
@@ -13643,12 +11773,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyflakes:{{revision}}
-  - name: path-context
-    value: packages/pyflakes
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyflakes/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13658,14 +11782,14 @@ spec:
         "path": "./packages/pyflakes",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyflakes
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13679,7 +11803,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pygithub/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pygithub
@@ -13694,12 +11817,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pygithub:{{revision}}
-  - name: path-context
-    value: packages/pygithub
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pygithub/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13709,14 +11826,14 @@ spec:
         "path": "./packages/pygithub",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pygithub
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13730,7 +11847,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pygments/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pygments
@@ -13745,12 +11861,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pygments:{{revision}}
-  - name: path-context
-    value: packages/pygments
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pygments/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13760,14 +11870,14 @@ spec:
         "path": "./packages/pygments",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pygments
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13781,7 +11891,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyjwt/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyjwt
@@ -13796,12 +11905,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyjwt:{{revision}}
-  - name: path-context
-    value: packages/pyjwt
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyjwt/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13811,14 +11914,14 @@ spec:
         "path": "./packages/pyjwt",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyjwt
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13832,7 +11935,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pylint/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pylint
@@ -13847,12 +11949,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pylint:{{revision}}
-  - name: path-context
-    value: packages/pylint
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pylint/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13862,14 +11958,14 @@ spec:
         "path": "./packages/pylint",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pylint
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13883,7 +11979,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pymongo/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pymongo
@@ -13898,12 +11993,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pymongo:{{revision}}
-  - name: path-context
-    value: packages/pymongo
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pymongo/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13913,14 +12002,14 @@ spec:
         "path": "./packages/pymongo",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pymongo
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13934,7 +12023,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pymysql/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pymysql
@@ -13949,12 +12037,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pymysql:{{revision}}
-  - name: path-context
-    value: packages/pymysql
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pymysql/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -13964,14 +12046,14 @@ spec:
         "path": "./packages/pymysql",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pymysql
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -13985,7 +12067,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyopenssl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyopenssl
@@ -14000,12 +12081,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyopenssl:{{revision}}
-  - name: path-context
-    value: packages/pyopenssl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyopenssl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14015,14 +12090,14 @@ spec:
         "path": "./packages/pyopenssl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyopenssl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14036,7 +12111,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyparsing/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyparsing
@@ -14051,12 +12125,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyparsing:{{revision}}
-  - name: path-context
-    value: packages/pyparsing
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyparsing/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14066,14 +12134,14 @@ spec:
         "path": "./packages/pyparsing",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyparsing
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14087,7 +12155,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyproject-api/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyproject-api
@@ -14102,12 +12169,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyproject-api:{{revision}}
-  - name: path-context
-    value: packages/pyproject-api
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyproject-api/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14117,14 +12178,14 @@ spec:
         "path": "./packages/pyproject-api",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyproject-api
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14138,7 +12199,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyproject-hooks/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyproject-hooks
@@ -14153,12 +12213,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyproject-hooks:{{revision}}
-  - name: path-context
-    value: packages/pyproject-hooks
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyproject-hooks/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14168,14 +12222,14 @@ spec:
         "path": "./packages/pyproject-hooks",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyproject-hooks
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14189,7 +12243,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyproject-metadata/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyproject-metadata
@@ -14204,12 +12257,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyproject-metadata:{{revision}}
-  - name: path-context
-    value: packages/pyproject-metadata
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyproject-metadata/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14219,14 +12266,14 @@ spec:
         "path": "./packages/pyproject-metadata",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyproject-metadata
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14240,7 +12287,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyrsistent/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyrsistent
@@ -14255,12 +12301,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyrsistent:{{revision}}
-  - name: path-context
-    value: packages/pyrsistent
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyrsistent/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14270,14 +12310,14 @@ spec:
         "path": "./packages/pyrsistent",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyrsistent
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14291,7 +12331,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyspark/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyspark
@@ -14306,12 +12345,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyspark:{{revision}}
-  - name: path-context
-    value: packages/pyspark
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyspark/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14321,14 +12354,14 @@ spec:
         "path": "./packages/pyspark",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyspark
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14342,7 +12375,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest
@@ -14357,12 +12389,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest:{{revision}}
-  - name: path-context
-    value: packages/pytest
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14372,14 +12398,14 @@ spec:
         "path": "./packages/pytest",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14393,7 +12419,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-asyncio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-asyncio
@@ -14408,12 +12433,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-asyncio:{{revision}}
-  - name: path-context
-    value: packages/pytest-asyncio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-asyncio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14423,14 +12442,14 @@ spec:
         "path": "./packages/pytest-asyncio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-asyncio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14444,7 +12463,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-cov/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-cov
@@ -14459,12 +12477,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-cov:{{revision}}
-  - name: path-context
-    value: packages/pytest-cov
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-cov/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14474,14 +12486,14 @@ spec:
         "path": "./packages/pytest-cov",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-cov
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14495,7 +12507,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-mock/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-mock
@@ -14510,12 +12521,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-mock:{{revision}}
-  - name: path-context
-    value: packages/pytest-mock
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-mock/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14525,14 +12530,14 @@ spec:
         "path": "./packages/pytest-mock",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-mock
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14546,7 +12551,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytest-xdist/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytest-xdist
@@ -14561,12 +12565,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pytest-xdist:{{revision}}
-  - name: path-context
-    value: packages/pytest-xdist
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytest-xdist/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14576,14 +12574,14 @@ spec:
         "path": "./packages/pytest-xdist",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytest-xdist
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14597,7 +12595,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-dateutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-dateutil
@@ -14612,12 +12609,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/python-dateutil:{{revision}}
-  - name: path-context
-    value: packages/python-dateutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-dateutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14627,14 +12618,14 @@ spec:
         "path": "./packages/python-dateutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-dateutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14648,7 +12639,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-dotenv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-dotenv
@@ -14663,12 +12653,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/python-dotenv:{{revision}}
-  - name: path-context
-    value: packages/python-dotenv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-dotenv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14678,14 +12662,14 @@ spec:
         "path": "./packages/python-dotenv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-dotenv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14699,7 +12683,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-json-logger/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-json-logger
@@ -14714,12 +12697,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/python-json-logger:{{revision}}
-  - name: path-context
-    value: packages/python-json-logger
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-json-logger/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14729,14 +12706,14 @@ spec:
         "path": "./packages/python-json-logger",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-json-logger
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14750,7 +12727,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-multipart/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-multipart
@@ -14765,12 +12741,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/python-multipart:{{revision}}
-  - name: path-context
-    value: packages/python-multipart
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-multipart/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14780,14 +12750,14 @@ spec:
         "path": "./packages/python-multipart",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-multipart
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14801,7 +12771,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-slugify/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-slugify
@@ -14816,12 +12785,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/python-slugify:{{revision}}
-  - name: path-context
-    value: packages/python-slugify
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-slugify/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14831,14 +12794,14 @@ spec:
         "path": "./packages/python-slugify",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-slugify
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14852,7 +12815,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/python-telegram-bot/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: python-telegram-bot
@@ -14867,12 +12829,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/python-telegram-bot:{{revision}}
-  - name: path-context
-    value: packages/python-telegram-bot
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/python-telegram-bot/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14882,14 +12838,14 @@ spec:
         "path": "./packages/python-telegram-bot",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: python-telegram-bot
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14903,7 +12859,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pytz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pytz
@@ -14918,12 +12873,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pytz:{{revision}}
-  - name: path-context
-    value: packages/pytz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pytz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14933,14 +12882,14 @@ spec:
         "path": "./packages/pytz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pytz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -14954,7 +12903,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/pyyaml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: pyyaml
@@ -14969,12 +12917,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/pyyaml:{{revision}}
-  - name: path-context
-    value: packages/pyyaml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/pyyaml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -14984,14 +12926,14 @@ spec:
         "path": "./packages/pyyaml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: pyyaml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15005,7 +12947,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/readme-renderer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: readme-renderer
@@ -15020,12 +12961,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/readme-renderer:{{revision}}
-  - name: path-context
-    value: packages/readme-renderer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/readme-renderer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15035,14 +12970,14 @@ spec:
         "path": "./packages/readme-renderer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: readme-renderer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15056,7 +12991,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/redis/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: redis
@@ -15071,12 +13005,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/redis:{{revision}}
-  - name: path-context
-    value: packages/redis
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/redis/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15086,14 +13014,14 @@ spec:
         "path": "./packages/redis",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: redis
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15107,7 +13035,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/regex/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: regex
@@ -15122,12 +13049,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/regex:{{revision}}
-  - name: path-context
-    value: packages/regex
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/regex/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15137,14 +13058,14 @@ spec:
         "path": "./packages/regex",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: regex
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15158,7 +13079,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/requests/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: requests
@@ -15173,12 +13093,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/requests:{{revision}}
-  - name: path-context
-    value: packages/requests
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/requests/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15188,14 +13102,14 @@ spec:
         "path": "./packages/requests",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: requests
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15209,7 +13123,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/requests-aws4auth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: requests-aws4auth
@@ -15224,12 +13137,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/requests-aws4auth:{{revision}}
-  - name: path-context
-    value: packages/requests-aws4auth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/requests-aws4auth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15239,14 +13146,14 @@ spec:
         "path": "./packages/requests-aws4auth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: requests-aws4auth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15260,7 +13167,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/requests-file/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: requests-file
@@ -15275,12 +13181,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/requests-file:{{revision}}
-  - name: path-context
-    value: packages/requests-file
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/requests-file/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15290,14 +13190,14 @@ spec:
         "path": "./packages/requests-file",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: requests-file
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15311,7 +13211,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/responses/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: responses
@@ -15326,12 +13225,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/responses:{{revision}}
-  - name: path-context
-    value: packages/responses
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/responses/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15341,14 +13234,14 @@ spec:
         "path": "./packages/responses",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: responses
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15362,7 +13255,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/retry/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: retry
@@ -15377,12 +13269,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/retry:{{revision}}
-  - name: path-context
-    value: packages/retry
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/retry/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15392,14 +13278,14 @@ spec:
         "path": "./packages/retry",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: retry
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15413,7 +13299,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rfc3339-validator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rfc3339-validator
@@ -15428,12 +13313,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/rfc3339-validator:{{revision}}
-  - name: path-context
-    value: packages/rfc3339-validator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rfc3339-validator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15443,14 +13322,14 @@ spec:
         "path": "./packages/rfc3339-validator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rfc3339-validator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15464,7 +13343,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rfc3986/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rfc3986
@@ -15479,12 +13357,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/rfc3986:{{revision}}
-  - name: path-context
-    value: packages/rfc3986
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rfc3986/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15494,14 +13366,14 @@ spec:
         "path": "./packages/rfc3986",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rfc3986
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15515,7 +13387,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rfc3986-validator/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rfc3986-validator
@@ -15530,12 +13401,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/rfc3986-validator:{{revision}}
-  - name: path-context
-    value: packages/rfc3986-validator
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rfc3986-validator/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15545,14 +13410,14 @@ spec:
         "path": "./packages/rfc3986-validator",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rfc3986-validator
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15566,7 +13431,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rich/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rich
@@ -15581,12 +13445,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/rich:{{revision}}
-  - name: path-context
-    value: packages/rich
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rich/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15596,14 +13454,14 @@ spec:
         "path": "./packages/rich",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rich
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15617,7 +13475,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rich-toolkit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rich-toolkit
@@ -15632,12 +13489,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/rich-toolkit:{{revision}}
-  - name: path-context
-    value: packages/rich-toolkit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rich-toolkit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15647,14 +13498,14 @@ spec:
         "path": "./packages/rich-toolkit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rich-toolkit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15668,7 +13519,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/rsa/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: rsa
@@ -15683,12 +13533,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/rsa:{{revision}}
-  - name: path-context
-    value: packages/rsa
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/rsa/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15698,14 +13542,14 @@ spec:
         "path": "./packages/rsa",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: rsa
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15719,7 +13563,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/s3fs/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: s3fs
@@ -15734,12 +13577,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/s3fs:{{revision}}
-  - name: path-context
-    value: packages/s3fs
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/s3fs/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15749,14 +13586,14 @@ spec:
         "path": "./packages/s3fs",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: s3fs
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15770,7 +13607,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/s3transfer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: s3transfer
@@ -15785,12 +13621,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/s3transfer:{{revision}}
-  - name: path-context
-    value: packages/s3transfer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/s3transfer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15800,14 +13630,14 @@ spec:
         "path": "./packages/s3transfer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: s3transfer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15821,7 +13651,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/schema/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: schema
@@ -15836,12 +13665,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/schema:{{revision}}
-  - name: path-context
-    value: packages/schema
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/schema/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15851,14 +13674,14 @@ spec:
         "path": "./packages/schema",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: schema
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15872,7 +13695,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/scikit-build-core/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: scikit-build-core
@@ -15887,12 +13709,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/scikit-build-core:{{revision}}
-  - name: path-context
-    value: packages/scikit-build-core
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/scikit-build-core/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15902,14 +13718,14 @@ spec:
         "path": "./packages/scikit-build-core",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: scikit-build-core
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15923,7 +13739,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/scramp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: scramp
@@ -15938,12 +13753,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/scramp:{{revision}}
-  - name: path-context
-    value: packages/scramp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/scramp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -15953,14 +13762,14 @@ spec:
         "path": "./packages/scramp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: scramp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -15974,7 +13783,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/seaborn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: seaborn
@@ -15989,12 +13797,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/seaborn:{{revision}}
-  - name: path-context
-    value: packages/seaborn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/seaborn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16004,14 +13806,14 @@ spec:
         "path": "./packages/seaborn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: seaborn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16025,7 +13827,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/semver/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: semver
@@ -16040,12 +13841,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/semver:{{revision}}
-  - name: path-context
-    value: packages/semver
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/semver/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16055,14 +13850,14 @@ spec:
         "path": "./packages/semver",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: semver
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16076,7 +13871,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sentry-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sentry-sdk
@@ -16091,12 +13885,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sentry-sdk:{{revision}}
-  - name: path-context
-    value: packages/sentry-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sentry-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16106,14 +13894,14 @@ spec:
         "path": "./packages/sentry-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sentry-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16127,7 +13915,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/setproctitle/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: setproctitle
@@ -16142,12 +13929,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/setproctitle:{{revision}}
-  - name: path-context
-    value: packages/setproctitle
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/setproctitle/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16157,14 +13938,14 @@ spec:
         "path": "./packages/setproctitle",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: setproctitle
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16178,7 +13959,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/setuptools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: setuptools
@@ -16193,12 +13973,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/setuptools:{{revision}}
-  - name: path-context
-    value: packages/setuptools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/setuptools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16208,14 +13982,14 @@ spec:
         "path": "./packages/setuptools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: setuptools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16229,7 +14003,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/setuptools-scm/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: setuptools-scm
@@ -16244,12 +14017,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/setuptools-scm:{{revision}}
-  - name: path-context
-    value: packages/setuptools-scm
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/setuptools-scm/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16259,14 +14026,14 @@ spec:
         "path": "./packages/setuptools-scm",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: setuptools-scm
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16280,7 +14047,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/shellingham/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: shellingham
@@ -16295,12 +14061,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/shellingham:{{revision}}
-  - name: path-context
-    value: packages/shellingham
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/shellingham/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16310,14 +14070,14 @@ spec:
         "path": "./packages/shellingham",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: shellingham
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16331,7 +14091,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/simplejson/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: simplejson
@@ -16346,12 +14105,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/simplejson:{{revision}}
-  - name: path-context
-    value: packages/simplejson
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/simplejson/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16361,14 +14114,14 @@ spec:
         "path": "./packages/simplejson",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: simplejson
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16382,7 +14135,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/six/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: six
@@ -16397,12 +14149,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/six:{{revision}}
-  - name: path-context
-    value: packages/six
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/six/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16412,14 +14158,14 @@ spec:
         "path": "./packages/six",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: six
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16433,7 +14179,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/slack-sdk/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: slack-sdk
@@ -16448,12 +14193,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/slack-sdk:{{revision}}
-  - name: path-context
-    value: packages/slack-sdk
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/slack-sdk/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16463,14 +14202,14 @@ spec:
         "path": "./packages/slack-sdk",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: slack-sdk
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16484,7 +14223,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/smart-open/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: smart-open
@@ -16499,12 +14237,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/smart-open:{{revision}}
-  - name: path-context
-    value: packages/smart-open
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/smart-open/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16514,14 +14246,14 @@ spec:
         "path": "./packages/smart-open",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: smart-open
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16535,7 +14267,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/smmap/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: smmap
@@ -16550,12 +14281,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/smmap:{{revision}}
-  - name: path-context
-    value: packages/smmap
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/smmap/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16565,14 +14290,14 @@ spec:
         "path": "./packages/smmap",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: smmap
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16586,7 +14311,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sniffio/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sniffio
@@ -16601,12 +14325,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sniffio:{{revision}}
-  - name: path-context
-    value: packages/sniffio
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sniffio/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16616,14 +14334,14 @@ spec:
         "path": "./packages/sniffio",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sniffio
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16637,7 +14355,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/snowflake-connector-python/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: snowflake-connector-python
@@ -16652,12 +14369,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/snowflake-connector-python:{{revision}}
-  - name: path-context
-    value: packages/snowflake-connector-python
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/snowflake-connector-python/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16667,14 +14378,14 @@ spec:
         "path": "./packages/snowflake-connector-python",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: snowflake-connector-python
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16688,7 +14399,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sortedcontainers/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sortedcontainers
@@ -16703,12 +14413,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sortedcontainers:{{revision}}
-  - name: path-context
-    value: packages/sortedcontainers
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sortedcontainers/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16718,14 +14422,14 @@ spec:
         "path": "./packages/sortedcontainers",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sortedcontainers
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16739,7 +14443,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/soupsieve/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: soupsieve
@@ -16754,12 +14457,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/soupsieve:{{revision}}
-  - name: path-context
-    value: packages/soupsieve
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/soupsieve/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16769,14 +14466,14 @@ spec:
         "path": "./packages/soupsieve",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: soupsieve
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16790,7 +14487,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sphinx/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sphinx
@@ -16805,12 +14501,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sphinx:{{revision}}
-  - name: path-context
-    value: packages/sphinx
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sphinx/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16820,14 +14510,14 @@ spec:
         "path": "./packages/sphinx",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sphinx
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16841,7 +14531,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlalchemy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlalchemy
@@ -16856,12 +14545,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlalchemy:{{revision}}
-  - name: path-context
-    value: packages/sqlalchemy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlalchemy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16871,14 +14554,14 @@ spec:
         "path": "./packages/sqlalchemy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlalchemy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16892,7 +14575,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlalchemy-bigquery/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlalchemy-bigquery
@@ -16907,12 +14589,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlalchemy-bigquery:{{revision}}
-  - name: path-context
-    value: packages/sqlalchemy-bigquery
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlalchemy-bigquery/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16922,14 +14598,14 @@ spec:
         "path": "./packages/sqlalchemy-bigquery",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlalchemy-bigquery
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16943,7 +14619,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlalchemy-spanner/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlalchemy-spanner
@@ -16958,12 +14633,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlalchemy-spanner:{{revision}}
-  - name: path-context
-    value: packages/sqlalchemy-spanner
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlalchemy-spanner/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -16973,14 +14642,14 @@ spec:
         "path": "./packages/sqlalchemy-spanner",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlalchemy-spanner
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -16994,7 +14663,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sqlparse/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sqlparse
@@ -17009,12 +14677,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sqlparse:{{revision}}
-  - name: path-context
-    value: packages/sqlparse
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sqlparse/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17024,14 +14686,14 @@ spec:
         "path": "./packages/sqlparse",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sqlparse
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17045,7 +14707,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sshtunnel/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sshtunnel
@@ -17060,12 +14721,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sshtunnel:{{revision}}
-  - name: path-context
-    value: packages/sshtunnel
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sshtunnel/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17075,14 +14730,14 @@ spec:
         "path": "./packages/sshtunnel",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sshtunnel
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17096,7 +14751,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/stack-data/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: stack-data
@@ -17111,12 +14765,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/stack-data:{{revision}}
-  - name: path-context
-    value: packages/stack-data
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/stack-data/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17126,14 +14774,14 @@ spec:
         "path": "./packages/stack-data",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: stack-data
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17147,7 +14795,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/starlette/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: starlette
@@ -17162,12 +14809,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/starlette:{{revision}}
-  - name: path-context
-    value: packages/starlette
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/starlette/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17177,14 +14818,14 @@ spec:
         "path": "./packages/starlette",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: starlette
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17198,7 +14839,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/sympy/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: sympy
@@ -17213,12 +14853,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/sympy:{{revision}}
-  - name: path-context
-    value: packages/sympy
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/sympy/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17228,14 +14862,14 @@ spec:
         "path": "./packages/sympy",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: sympy
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17249,7 +14883,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tableauserverclient/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tableauserverclient
@@ -17264,12 +14897,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tableauserverclient:{{revision}}
-  - name: path-context
-    value: packages/tableauserverclient
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tableauserverclient/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17279,14 +14906,14 @@ spec:
         "path": "./packages/tableauserverclient",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tableauserverclient
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17300,7 +14927,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tabulate/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tabulate
@@ -17315,12 +14941,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tabulate:{{revision}}
-  - name: path-context
-    value: packages/tabulate
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tabulate/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17330,14 +14950,14 @@ spec:
         "path": "./packages/tabulate",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tabulate
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17351,7 +14971,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tblib/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tblib
@@ -17366,12 +14985,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tblib:{{revision}}
-  - name: path-context
-    value: packages/tblib
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tblib/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17381,14 +14994,14 @@ spec:
         "path": "./packages/tblib",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tblib
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17402,7 +15015,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tenacity/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tenacity
@@ -17417,12 +15029,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tenacity:{{revision}}
-  - name: path-context
-    value: packages/tenacity
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tenacity/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17432,14 +15038,14 @@ spec:
         "path": "./packages/tenacity",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tenacity
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17453,7 +15059,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/termcolor/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: termcolor
@@ -17468,12 +15073,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/termcolor:{{revision}}
-  - name: path-context
-    value: packages/termcolor
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/termcolor/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17483,14 +15082,14 @@ spec:
         "path": "./packages/termcolor",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: termcolor
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17504,7 +15103,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/terminado/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: terminado
@@ -17519,12 +15117,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/terminado:{{revision}}
-  - name: path-context
-    value: packages/terminado
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/terminado/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17534,14 +15126,14 @@ spec:
         "path": "./packages/terminado",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: terminado
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17555,7 +15147,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/threadpoolctl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: threadpoolctl
@@ -17570,12 +15161,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/threadpoolctl:{{revision}}
-  - name: path-context
-    value: packages/threadpoolctl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/threadpoolctl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17585,14 +15170,14 @@ spec:
         "path": "./packages/threadpoolctl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: threadpoolctl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17606,7 +15191,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/thrift/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: thrift
@@ -17621,12 +15205,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/thrift:{{revision}}
-  - name: path-context
-    value: packages/thrift
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/thrift/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17636,14 +15214,14 @@ spec:
         "path": "./packages/thrift",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: thrift
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17657,7 +15235,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/thriftpy2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: thriftpy2
@@ -17672,12 +15249,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/thriftpy2:{{revision}}
-  - name: path-context
-    value: packages/thriftpy2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/thriftpy2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17687,14 +15258,14 @@ spec:
         "path": "./packages/thriftpy2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: thriftpy2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17708,7 +15279,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tinycss2/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tinycss2
@@ -17723,12 +15293,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tinycss2:{{revision}}
-  - name: path-context
-    value: packages/tinycss2
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tinycss2/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17738,14 +15302,14 @@ spec:
         "path": "./packages/tinycss2",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tinycss2
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17759,7 +15323,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/toml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: toml
@@ -17774,12 +15337,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/toml:{{revision}}
-  - name: path-context
-    value: packages/toml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/toml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17789,14 +15346,14 @@ spec:
         "path": "./packages/toml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: toml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17810,7 +15367,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tomlkit/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tomlkit
@@ -17825,12 +15381,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tomlkit:{{revision}}
-  - name: path-context
-    value: packages/tomlkit
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tomlkit/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17840,14 +15390,14 @@ spec:
         "path": "./packages/tomlkit",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tomlkit
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17861,7 +15411,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/toolz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: toolz
@@ -17876,12 +15425,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/toolz:{{revision}}
-  - name: path-context
-    value: packages/toolz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/toolz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17891,14 +15434,14 @@ spec:
         "path": "./packages/toolz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: toolz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17912,7 +15455,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tornado/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tornado
@@ -17927,12 +15469,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tornado:{{revision}}
-  - name: path-context
-    value: packages/tornado
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tornado/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17942,14 +15478,14 @@ spec:
         "path": "./packages/tornado",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tornado
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -17963,7 +15499,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tox/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tox
@@ -17978,12 +15513,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tox:{{revision}}
-  - name: path-context
-    value: packages/tox
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tox/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -17993,14 +15522,14 @@ spec:
         "path": "./packages/tox",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tox
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18014,7 +15543,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tqdm/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tqdm
@@ -18029,12 +15557,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tqdm:{{revision}}
-  - name: path-context
-    value: packages/tqdm
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tqdm/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18044,14 +15566,14 @@ spec:
         "path": "./packages/tqdm",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tqdm
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18065,7 +15587,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/traitlets/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: traitlets
@@ -18080,12 +15601,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/traitlets:{{revision}}
-  - name: path-context
-    value: packages/traitlets
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/traitlets/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18095,14 +15610,14 @@ spec:
         "path": "./packages/traitlets",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: traitlets
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18116,7 +15631,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/trove-classifiers/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: trove-classifiers
@@ -18131,12 +15645,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/trove-classifiers:{{revision}}
-  - name: path-context
-    value: packages/trove-classifiers
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/trove-classifiers/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18146,14 +15654,14 @@ spec:
         "path": "./packages/trove-classifiers",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: trove-classifiers
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18167,7 +15675,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typeguard/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typeguard
@@ -18182,12 +15689,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/typeguard:{{revision}}
-  - name: path-context
-    value: packages/typeguard
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typeguard/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18197,14 +15698,14 @@ spec:
         "path": "./packages/typeguard",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typeguard
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18218,7 +15719,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typer/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typer
@@ -18233,12 +15733,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/typer:{{revision}}
-  - name: path-context
-    value: packages/typer
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typer/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18248,14 +15742,14 @@ spec:
         "path": "./packages/typer",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typer
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18269,7 +15763,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-protobuf/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-protobuf
@@ -18284,12 +15777,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-protobuf:{{revision}}
-  - name: path-context
-    value: packages/types-protobuf
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-protobuf/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18299,14 +15786,14 @@ spec:
         "path": "./packages/types-protobuf",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-protobuf
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18320,7 +15807,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-psutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-psutil
@@ -18335,12 +15821,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-psutil:{{revision}}
-  - name: path-context
-    value: packages/types-psutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-psutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18350,14 +15830,14 @@ spec:
         "path": "./packages/types-psutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-psutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18371,7 +15851,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-python-dateutil/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-python-dateutil
@@ -18386,12 +15865,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-python-dateutil:{{revision}}
-  - name: path-context
-    value: packages/types-python-dateutil
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-python-dateutil/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18401,14 +15874,14 @@ spec:
         "path": "./packages/types-python-dateutil",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-python-dateutil
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18422,7 +15895,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-pytz/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-pytz
@@ -18437,12 +15909,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-pytz:{{revision}}
-  - name: path-context
-    value: packages/types-pytz
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-pytz/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18452,14 +15918,14 @@ spec:
         "path": "./packages/types-pytz",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-pytz
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18473,7 +15939,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-pyyaml/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-pyyaml
@@ -18488,12 +15953,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-pyyaml:{{revision}}
-  - name: path-context
-    value: packages/types-pyyaml
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-pyyaml/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18503,14 +15962,14 @@ spec:
         "path": "./packages/types-pyyaml",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-pyyaml
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18524,7 +15983,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-requests/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-requests
@@ -18539,12 +15997,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-requests:{{revision}}
-  - name: path-context
-    value: packages/types-requests
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-requests/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18554,14 +16006,14 @@ spec:
         "path": "./packages/types-requests",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-requests
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18575,7 +16027,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/types-setuptools/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: types-setuptools
@@ -18590,12 +16041,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/types-setuptools:{{revision}}
-  - name: path-context
-    value: packages/types-setuptools
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/types-setuptools/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18605,14 +16050,14 @@ spec:
         "path": "./packages/types-setuptools",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: types-setuptools
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18626,7 +16071,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typing-extensions/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typing-extensions
@@ -18641,12 +16085,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/typing-extensions:{{revision}}
-  - name: path-context
-    value: packages/typing-extensions
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typing-extensions/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18656,14 +16094,14 @@ spec:
         "path": "./packages/typing-extensions",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typing-extensions
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18677,7 +16115,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typing-inspect/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typing-inspect
@@ -18692,12 +16129,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/typing-inspect:{{revision}}
-  - name: path-context
-    value: packages/typing-inspect
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typing-inspect/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18707,14 +16138,14 @@ spec:
         "path": "./packages/typing-inspect",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typing-inspect
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18728,7 +16159,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/typing-inspection/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: typing-inspection
@@ -18743,12 +16173,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/typing-inspection:{{revision}}
-  - name: path-context
-    value: packages/typing-inspection
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/typing-inspection/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18758,14 +16182,14 @@ spec:
         "path": "./packages/typing-inspection",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: typing-inspection
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18779,7 +16203,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tzdata/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tzdata
@@ -18794,12 +16217,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tzdata:{{revision}}
-  - name: path-context
-    value: packages/tzdata
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tzdata/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18809,14 +16226,14 @@ spec:
         "path": "./packages/tzdata",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tzdata
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18830,7 +16247,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/tzlocal/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: tzlocal
@@ -18845,12 +16261,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/tzlocal:{{revision}}
-  - name: path-context
-    value: packages/tzlocal
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/tzlocal/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18860,14 +16270,14 @@ spec:
         "path": "./packages/tzlocal",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: tzlocal
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18881,7 +16291,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/urllib3/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: urllib3
@@ -18896,12 +16305,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/urllib3:{{revision}}
-  - name: path-context
-    value: packages/urllib3
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/urllib3/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18911,14 +16314,14 @@ spec:
         "path": "./packages/urllib3",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: urllib3
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18932,7 +16335,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/uvicorn/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: uvicorn
@@ -18947,12 +16349,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/uvicorn:{{revision}}
-  - name: path-context
-    value: packages/uvicorn
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/uvicorn/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -18962,14 +16358,14 @@ spec:
         "path": "./packages/uvicorn",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: uvicorn
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -18983,7 +16379,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/uvloop/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: uvloop
@@ -18998,12 +16393,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/uvloop:{{revision}}
-  - name: path-context
-    value: packages/uvloop
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/uvloop/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19013,14 +16402,14 @@ spec:
         "path": "./packages/uvloop",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: uvloop
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19034,7 +16423,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/virtualenv/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: virtualenv
@@ -19049,12 +16437,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/virtualenv:{{revision}}
-  - name: path-context
-    value: packages/virtualenv
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/virtualenv/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19064,14 +16446,14 @@ spec:
         "path": "./packages/virtualenv",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: virtualenv
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19085,7 +16467,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/watchdog/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: watchdog
@@ -19100,12 +16481,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/watchdog:{{revision}}
-  - name: path-context
-    value: packages/watchdog
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/watchdog/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19115,14 +16490,14 @@ spec:
         "path": "./packages/watchdog",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: watchdog
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19136,7 +16511,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wcwidth/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wcwidth
@@ -19151,12 +16525,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/wcwidth:{{revision}}
-  - name: path-context
-    value: packages/wcwidth
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wcwidth/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19166,14 +16534,14 @@ spec:
         "path": "./packages/wcwidth",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wcwidth
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19187,7 +16555,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/weaviate-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: weaviate-client
@@ -19202,12 +16569,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/weaviate-client:{{revision}}
-  - name: path-context
-    value: packages/weaviate-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/weaviate-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19217,14 +16578,14 @@ spec:
         "path": "./packages/weaviate-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: weaviate-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19238,7 +16599,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/webcolors/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: webcolors
@@ -19253,12 +16613,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/webcolors:{{revision}}
-  - name: path-context
-    value: packages/webcolors
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/webcolors/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19268,14 +16622,14 @@ spec:
         "path": "./packages/webcolors",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: webcolors
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19289,7 +16643,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/webencodings/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: webencodings
@@ -19304,12 +16657,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/webencodings:{{revision}}
-  - name: path-context
-    value: packages/webencodings
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/webencodings/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19319,14 +16666,14 @@ spec:
         "path": "./packages/webencodings",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: webencodings
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19340,7 +16687,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/websocket-client/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: websocket-client
@@ -19355,12 +16701,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/websocket-client:{{revision}}
-  - name: path-context
-    value: packages/websocket-client
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/websocket-client/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19370,14 +16710,14 @@ spec:
         "path": "./packages/websocket-client",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: websocket-client
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19391,7 +16731,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/websockets/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: websockets
@@ -19406,12 +16745,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/websockets:{{revision}}
-  - name: path-context
-    value: packages/websockets
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/websockets/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19421,14 +16754,14 @@ spec:
         "path": "./packages/websockets",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: websockets
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19442,7 +16775,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/werkzeug/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: werkzeug
@@ -19457,12 +16789,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/werkzeug:{{revision}}
-  - name: path-context
-    value: packages/werkzeug
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/werkzeug/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19472,14 +16798,14 @@ spec:
         "path": "./packages/werkzeug",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: werkzeug
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19493,7 +16819,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wheel/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wheel
@@ -19508,12 +16833,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/wheel:{{revision}}
-  - name: path-context
-    value: packages/wheel
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wheel/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19523,14 +16842,14 @@ spec:
         "path": "./packages/wheel",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wheel
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19544,7 +16863,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/widgetsnbextension/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: widgetsnbextension
@@ -19559,12 +16877,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/widgetsnbextension:{{revision}}
-  - name: path-context
-    value: packages/widgetsnbextension
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/widgetsnbextension/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19574,14 +16886,14 @@ spec:
         "path": "./packages/widgetsnbextension",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: widgetsnbextension
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19595,7 +16907,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wrapt/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wrapt
@@ -19610,12 +16921,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/wrapt:{{revision}}
-  - name: path-context
-    value: packages/wrapt
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wrapt/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19625,14 +16930,14 @@ spec:
         "path": "./packages/wrapt",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wrapt
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19646,7 +16951,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/wsproto/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: wsproto
@@ -19661,12 +16965,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/wsproto:{{revision}}
-  - name: path-context
-    value: packages/wsproto
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/wsproto/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19676,14 +16974,14 @@ spec:
         "path": "./packages/wsproto",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: wsproto
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19697,7 +16995,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/xlsxwriter/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: xlsxwriter
@@ -19712,12 +17009,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/xlsxwriter:{{revision}}
-  - name: path-context
-    value: packages/xlsxwriter
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/xlsxwriter/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19727,14 +17018,14 @@ spec:
         "path": "./packages/xlsxwriter",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: xlsxwriter
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19748,7 +17039,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/xmltodict/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: xmltodict
@@ -19763,12 +17053,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/xmltodict:{{revision}}
-  - name: path-context
-    value: packages/xmltodict
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/xmltodict/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19778,14 +17062,14 @@ spec:
         "path": "./packages/xmltodict",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: xmltodict
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19799,7 +17083,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/xyzservices/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: xyzservices
@@ -19814,12 +17097,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/xyzservices:{{revision}}
-  - name: path-context
-    value: packages/xyzservices
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/xyzservices/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19829,14 +17106,14 @@ spec:
         "path": "./packages/xyzservices",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: xyzservices
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19850,7 +17127,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/yamllint/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: yamllint
@@ -19865,12 +17141,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/yamllint:{{revision}}
-  - name: path-context
-    value: packages/yamllint
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/yamllint/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19880,14 +17150,14 @@ spec:
         "path": "./packages/yamllint",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: yamllint
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19901,7 +17171,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/yandexcloud/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: yandexcloud
@@ -19916,12 +17185,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/yandexcloud:{{revision}}
-  - name: path-context
-    value: packages/yandexcloud
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/yandexcloud/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19931,14 +17194,14 @@ spec:
         "path": "./packages/yandexcloud",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: yandexcloud
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -19952,7 +17215,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/yarl/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: yarl
@@ -19967,12 +17229,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/yarl:{{revision}}
-  - name: path-context
-    value: packages/yarl
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/yarl/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -19982,14 +17238,14 @@ spec:
         "path": "./packages/yarl",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: yarl
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20003,7 +17259,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/zipp/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: zipp
@@ -20018,12 +17273,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/zipp:{{revision}}
-  - name: path-context
-    value: packages/zipp
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/zipp/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20033,14 +17282,14 @@ spec:
         "path": "./packages/zipp",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: zipp
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}
 ---
 apiVersion: tekton.dev/v1
 kind: PipelineRun
@@ -20054,7 +17303,6 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-path-change: "[packages/zstandard/**]"
-  creationTimestamp: null
   labels:
     appstudio.openshift.io/application: calunga
     appstudio.openshift.io/component: zstandard
@@ -20069,12 +17317,6 @@ spec:
     value: '{{revision}}'
   - name: output-image
     value: quay.io/redhat-user-workloads/calunga-tenant/zstandard:{{revision}}
-  - name: path-context
-    value: packages/zstandard
-  - name: dockerfile
-    value: Containerfile
-  - name: build-args-file
-    value: packages/zstandard/argfile.conf
   - name: hermetic
     value: "true"
   - name: prefetch-input
@@ -20084,11 +17326,11 @@ spec:
         "path": "./packages/zstandard",
         "allow_binary": "false"
       }
+  - name: package-name
+    value: zstandard
   pipelineRef:
     name: build
-  taskRunTemplate: {}
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-status: {}

--- a/.tekton/packages-on-push.yaml
+++ b/.tekton/packages-on-push.yaml
@@ -35,7 +35,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: absl-py
+    value: absl_py
   pipelineRef:
     name: build
   workspaces:
@@ -387,7 +387,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: annotated-types
+    value: annotated_types
   pipelineRef:
     name: build
   workspaces:
@@ -563,7 +563,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: argon2-cffi
+    value: argon2_cffi
   pipelineRef:
     name: build
   workspaces:
@@ -827,7 +827,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: async-lru
+    value: async_lru
   pipelineRef:
     name: build
   workspaces:
@@ -871,7 +871,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: async-timeout
+    value: async_timeout
   pipelineRef:
     name: build
   workspaces:
@@ -1003,7 +1003,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: aws-lambda-powertools
+    value: aws_lambda_powertools
   pipelineRef:
     name: build
   workspaces:
@@ -1135,7 +1135,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-core
+    value: azure_core
   pipelineRef:
     name: build
   workspaces:
@@ -1179,7 +1179,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-identity
+    value: azure_identity
   pipelineRef:
     name: build
   workspaces:
@@ -1223,7 +1223,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-keyvault-secrets
+    value: azure_keyvault_secrets
   pipelineRef:
     name: build
   workspaces:
@@ -1267,7 +1267,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-storage-blob
+    value: azure_storage_blob
   pipelineRef:
     name: build
   workspaces:
@@ -1311,7 +1311,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: azure-storage-file-datalake
+    value: azure_storage_file_datalake
   pipelineRef:
     name: build
   workspaces:
@@ -1443,7 +1443,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: backports-tarfile
+    value: backports_tarfile
   pipelineRef:
     name: build
   workspaces:
@@ -2147,7 +2147,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: charset-normalizer
+    value: charset_normalizer
   pipelineRef:
     name: build
   workspaces:
@@ -2279,7 +2279,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: click-plugins
+    value: click_plugins
   pipelineRef:
     name: build
   workspaces:
@@ -2719,7 +2719,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: databricks-sdk
+    value: databricks_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -2763,7 +2763,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: databricks-sql-connector
+    value: databricks_sql_connector
   pipelineRef:
     name: build
   workspaces:
@@ -2807,7 +2807,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: dataclasses-json
+    value: dataclasses_json
   pipelineRef:
     name: build
   workspaces:
@@ -3335,7 +3335,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: docstring-parser
+    value: docstring_parser
   pipelineRef:
     name: build
   workspaces:
@@ -3599,7 +3599,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: email-validator
+    value: email_validator
   pipelineRef:
     name: build
   workspaces:
@@ -3643,7 +3643,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: et-xmlfile
+    value: et_xmlfile
   pipelineRef:
     name: build
   workspaces:
@@ -4479,7 +4479,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: gcloud-aio-auth
+    value: gcloud_aio_auth
   pipelineRef:
     name: build
   workspaces:
@@ -4523,7 +4523,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: gcloud-aio-bigquery
+    value: gcloud_aio_bigquery
   pipelineRef:
     name: build
   workspaces:
@@ -4743,7 +4743,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-ads
+    value: google_ads
   pipelineRef:
     name: build
   workspaces:
@@ -4787,7 +4787,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-api-core
+    value: google_api_core
   pipelineRef:
     name: build
   workspaces:
@@ -4831,7 +4831,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-api-python-client
+    value: google_api_python_client
   pipelineRef:
     name: build
   workspaces:
@@ -4875,7 +4875,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-auth
+    value: google_auth
   pipelineRef:
     name: build
   workspaces:
@@ -4919,7 +4919,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-auth-oauthlib
+    value: google_auth_oauthlib
   pipelineRef:
     name: build
   workspaces:
@@ -4963,7 +4963,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-aiplatform
+    value: google_cloud_aiplatform
   pipelineRef:
     name: build
   workspaces:
@@ -5007,7 +5007,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-audit-log
+    value: google_cloud_audit_log
   pipelineRef:
     name: build
   workspaces:
@@ -5051,7 +5051,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-bigquery
+    value: google_cloud_bigquery
   pipelineRef:
     name: build
   workspaces:
@@ -5095,7 +5095,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-bigquery-storage
+    value: google_cloud_bigquery_storage
   pipelineRef:
     name: build
   workspaces:
@@ -5139,7 +5139,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-bigtable
+    value: google_cloud_bigtable
   pipelineRef:
     name: build
   workspaces:
@@ -5183,7 +5183,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-dataproc
+    value: google_cloud_dataproc
   pipelineRef:
     name: build
   workspaces:
@@ -5227,7 +5227,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-logging
+    value: google_cloud_logging
   pipelineRef:
     name: build
   workspaces:
@@ -5271,7 +5271,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-pubsub
+    value: google_cloud_pubsub
   pipelineRef:
     name: build
   workspaces:
@@ -5315,7 +5315,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-resource-manager
+    value: google_cloud_resource_manager
   pipelineRef:
     name: build
   workspaces:
@@ -5359,7 +5359,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-secret-manager
+    value: google_cloud_secret_manager
   pipelineRef:
     name: build
   workspaces:
@@ -5403,7 +5403,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-storage
+    value: google_cloud_storage
   pipelineRef:
     name: build
   workspaces:
@@ -5447,7 +5447,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-cloud-vision
+    value: google_cloud_vision
   pipelineRef:
     name: build
   workspaces:
@@ -5491,7 +5491,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-crc32c
+    value: google_crc32c
   pipelineRef:
     name: build
   workspaces:
@@ -5535,7 +5535,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: google-resumable-media
+    value: google_resumable_media
   pipelineRef:
     name: build
   workspaces:
@@ -5579,7 +5579,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: googleapis-common-protos
+    value: googleapis_common_protos
   pipelineRef:
     name: build
   workspaces:
@@ -5623,7 +5623,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: graphql-core
+    value: graphql_core
   pipelineRef:
     name: build
   workspaces:
@@ -5755,7 +5755,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpc-google-iam-v1
+    value: grpc_google_iam_v1
   pipelineRef:
     name: build
   workspaces:
@@ -5843,7 +5843,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpcio-health-checking
+    value: grpcio_health_checking
   pipelineRef:
     name: build
   workspaces:
@@ -5887,7 +5887,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpcio-status
+    value: grpcio_status
   pipelineRef:
     name: build
   workspaces:
@@ -5931,7 +5931,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: grpcio-tools
+    value: grpcio_tools
   pipelineRef:
     name: build
   workspaces:
@@ -6107,7 +6107,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: hatch-fancy-pypi-readme
+    value: hatch_fancy_pypi_readme
   pipelineRef:
     name: build
   workspaces:
@@ -6151,7 +6151,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: hatch-vcs
+    value: hatch_vcs
   pipelineRef:
     name: build
   workspaces:
@@ -6767,7 +6767,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: importlib-metadata
+    value: importlib_metadata
   pipelineRef:
     name: build
   workspaces:
@@ -6811,7 +6811,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: importlib-resources
+    value: importlib_resources
   pipelineRef:
     name: build
   workspaces:
@@ -7207,7 +7207,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jaraco-context
+    value: jaraco_context
   pipelineRef:
     name: build
   workspaces:
@@ -7251,7 +7251,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jaraco-functools
+    value: jaraco_functools
   pipelineRef:
     name: build
   workspaces:
@@ -7647,7 +7647,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jupyter-client
+    value: jupyter_client
   pipelineRef:
     name: build
   workspaces:
@@ -7691,7 +7691,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: jupyter-core
+    value: jupyter_core
   pipelineRef:
     name: build
   workspaces:
@@ -7911,7 +7911,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: langchain-core
+    value: langchain_core
   pipelineRef:
     name: build
   workspaces:
@@ -7999,7 +7999,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: lazy-object-proxy
+    value: lazy_object_proxy
   pipelineRef:
     name: build
   workspaces:
@@ -8439,7 +8439,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: matplotlib-inline
+    value: matplotlib_inline
   pipelineRef:
     name: build
   workspaces:
@@ -8571,7 +8571,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: meson-python
+    value: meson_python
   pipelineRef:
     name: build
   workspaces:
@@ -8615,7 +8615,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: microsoft-kiota-http
+    value: microsoft_kiota_http
   pipelineRef:
     name: build
   workspaces:
@@ -8747,7 +8747,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: more-itertools
+    value: more_itertools
   pipelineRef:
     name: build
   workspaces:
@@ -8879,7 +8879,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: msal-extensions
+    value: msal_extensions
   pipelineRef:
     name: build
   workspaces:
@@ -9099,7 +9099,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: mypy-extensions
+    value: mypy_extensions
   pipelineRef:
     name: build
   workspaces:
@@ -9187,7 +9187,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: nest-asyncio
+    value: nest_asyncio
   pipelineRef:
     name: build
   workspaces:
@@ -9583,7 +9583,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-exporter-otlp
+    value: opentelemetry_exporter_otlp
   pipelineRef:
     name: build
   workspaces:
@@ -9627,7 +9627,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-exporter-prometheus
+    value: opentelemetry_exporter_prometheus
   pipelineRef:
     name: build
   workspaces:
@@ -9671,7 +9671,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-instrumentation
+    value: opentelemetry_instrumentation
   pipelineRef:
     name: build
   workspaces:
@@ -9715,7 +9715,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-instrumentation-requests
+    value: opentelemetry_instrumentation_requests
   pipelineRef:
     name: build
   workspaces:
@@ -9759,7 +9759,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-proto
+    value: opentelemetry_proto
   pipelineRef:
     name: build
   workspaces:
@@ -9803,7 +9803,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-sdk
+    value: opentelemetry_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -9847,7 +9847,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-semantic-conventions
+    value: opentelemetry_semantic_conventions
   pipelineRef:
     name: build
   workspaces:
@@ -9891,7 +9891,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: opentelemetry-util-http
+    value: opentelemetry_util_http
   pipelineRef:
     name: build
   workspaces:
@@ -10111,7 +10111,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pandas-gbq
+    value: pandas_gbq
   pipelineRef:
     name: build
   workspaces:
@@ -10683,7 +10683,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pkgutil-resolve-name
+    value: pkgutil_resolve_name
   pipelineRef:
     name: build
   workspaces:
@@ -10859,7 +10859,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: poetry-core
+    value: poetry_core
   pipelineRef:
     name: build
   workspaces:
@@ -10903,7 +10903,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: poetry-plugin-export
+    value: poetry_plugin_export
   pipelineRef:
     name: build
   workspaces:
@@ -10991,7 +10991,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pre-commit
+    value: pre_commit
   pipelineRef:
     name: build
   workspaces:
@@ -11035,7 +11035,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: prometheus-client
+    value: prometheus_client
   pipelineRef:
     name: build
   workspaces:
@@ -11079,7 +11079,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: prompt-toolkit
+    value: prompt_toolkit
   pipelineRef:
     name: build
   workspaces:
@@ -11167,7 +11167,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: proto-plus
+    value: proto_plus
   pipelineRef:
     name: build
   workspaces:
@@ -11343,7 +11343,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pure-eval
+    value: pure_eval
   pipelineRef:
     name: build
   workspaces:
@@ -11519,7 +11519,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyasn1-modules
+    value: pyasn1_modules
   pipelineRef:
     name: build
   workspaces:
@@ -11739,7 +11739,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pydantic-settings
+    value: pydantic_settings
   pipelineRef:
     name: build
   workspaces:
@@ -12179,7 +12179,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyproject-api
+    value: pyproject_api
   pipelineRef:
     name: build
   workspaces:
@@ -12223,7 +12223,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyproject-hooks
+    value: pyproject_hooks
   pipelineRef:
     name: build
   workspaces:
@@ -12267,7 +12267,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pyproject-metadata
+    value: pyproject_metadata
   pipelineRef:
     name: build
   workspaces:
@@ -12443,7 +12443,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-asyncio
+    value: pytest_asyncio
   pipelineRef:
     name: build
   workspaces:
@@ -12487,7 +12487,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-cov
+    value: pytest_cov
   pipelineRef:
     name: build
   workspaces:
@@ -12531,7 +12531,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-mock
+    value: pytest_mock
   pipelineRef:
     name: build
   workspaces:
@@ -12575,7 +12575,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: pytest-xdist
+    value: pytest_xdist
   pipelineRef:
     name: build
   workspaces:
@@ -12663,7 +12663,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-dotenv
+    value: python_dotenv
   pipelineRef:
     name: build
   workspaces:
@@ -12707,7 +12707,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-json-logger
+    value: python_json_logger
   pipelineRef:
     name: build
   workspaces:
@@ -12751,7 +12751,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-multipart
+    value: python_multipart
   pipelineRef:
     name: build
   workspaces:
@@ -12839,7 +12839,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: python-telegram-bot
+    value: python_telegram_bot
   pipelineRef:
     name: build
   workspaces:
@@ -12971,7 +12971,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: readme-renderer
+    value: readme_renderer
   pipelineRef:
     name: build
   workspaces:
@@ -13147,7 +13147,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: requests-aws4auth
+    value: requests_aws4auth
   pipelineRef:
     name: build
   workspaces:
@@ -13191,7 +13191,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: requests-file
+    value: requests_file
   pipelineRef:
     name: build
   workspaces:
@@ -13323,7 +13323,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: rfc3339-validator
+    value: rfc3339_validator
   pipelineRef:
     name: build
   workspaces:
@@ -13411,7 +13411,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: rfc3986-validator
+    value: rfc3986_validator
   pipelineRef:
     name: build
   workspaces:
@@ -13499,7 +13499,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: rich-toolkit
+    value: rich_toolkit
   pipelineRef:
     name: build
   workspaces:
@@ -13719,7 +13719,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: scikit-build-core
+    value: scikit_build_core
   pipelineRef:
     name: build
   workspaces:
@@ -13895,7 +13895,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: sentry-sdk
+    value: sentry_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -14027,7 +14027,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: setuptools-scm
+    value: setuptools_scm
   pipelineRef:
     name: build
   workspaces:
@@ -14203,7 +14203,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: slack-sdk
+    value: slack_sdk
   pipelineRef:
     name: build
   workspaces:
@@ -14247,7 +14247,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: smart-open
+    value: smart_open
   pipelineRef:
     name: build
   workspaces:
@@ -14379,7 +14379,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: snowflake-connector-python
+    value: snowflake_connector_python
   pipelineRef:
     name: build
   workspaces:
@@ -14599,7 +14599,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: sqlalchemy-bigquery
+    value: sqlalchemy_bigquery
   pipelineRef:
     name: build
   workspaces:
@@ -14643,7 +14643,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: sqlalchemy-spanner
+    value: sqlalchemy_spanner
   pipelineRef:
     name: build
   workspaces:
@@ -14775,7 +14775,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: stack-data
+    value: stack_data
   pipelineRef:
     name: build
   workspaces:
@@ -15655,7 +15655,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: trove-classifiers
+    value: trove_classifiers
   pipelineRef:
     name: build
   workspaces:
@@ -15787,7 +15787,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-protobuf
+    value: types_protobuf
   pipelineRef:
     name: build
   workspaces:
@@ -15831,7 +15831,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-psutil
+    value: types_psutil
   pipelineRef:
     name: build
   workspaces:
@@ -15875,7 +15875,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-python-dateutil
+    value: types_python_dateutil
   pipelineRef:
     name: build
   workspaces:
@@ -15919,7 +15919,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-pytz
+    value: types_pytz
   pipelineRef:
     name: build
   workspaces:
@@ -15963,7 +15963,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-pyyaml
+    value: types_pyyaml
   pipelineRef:
     name: build
   workspaces:
@@ -16007,7 +16007,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-requests
+    value: types_requests
   pipelineRef:
     name: build
   workspaces:
@@ -16051,7 +16051,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: types-setuptools
+    value: types_setuptools
   pipelineRef:
     name: build
   workspaces:
@@ -16095,7 +16095,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: typing-extensions
+    value: typing_extensions
   pipelineRef:
     name: build
   workspaces:
@@ -16139,7 +16139,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: typing-inspect
+    value: typing_inspect
   pipelineRef:
     name: build
   workspaces:
@@ -16183,7 +16183,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: typing-inspection
+    value: typing_inspection
   pipelineRef:
     name: build
   workspaces:
@@ -16579,7 +16579,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: weaviate-client
+    value: weaviate_client
   pipelineRef:
     name: build
   workspaces:
@@ -16711,7 +16711,7 @@ spec:
         "allow_binary": "false"
       }
   - name: package-name
-    value: websocket-client
+    value: websocket_client
   pipelineRef:
     name: build
   workspaces:

--- a/mark-for-rebuild.sh
+++ b/mark-for-rebuild.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 
 PACKAGE_NAME="$1"
 
-ARGFILE_CONF="packages/${PACKAGE_NAME}/argfile.conf"
+PYPROJECT_TOML="packages/${PACKAGE_NAME}/pyproject.toml"
 
 # Remove previous force rebuild comment
-sed -i '/^# Add comment to force rebuild/d' "$ARGFILE_CONF"
+sed -i '/^# Add comment to force rebuild/d' "$PYPROJECT_TOML"
 
-echo "# Add comment to force rebuild, $(date -u --rfc-3339=seconds)" >> "$ARGFILE_CONF"
+echo "# Add comment to force rebuild, $(date -u --rfc-3339=seconds)" >> "$PYPROJECT_TOML"

--- a/packages/additional-requirements.yaml
+++ b/packages/additional-requirements.yaml
@@ -105,6 +105,8 @@ packages:
   jsonpointer:
     requirements_in:
       - setuptools
+  markdown-it-py:
+    package_name: markdown-it-py
   mccabe:
     requirements_in:
       - setuptools

--- a/packages/werkzeug/pyproject.toml
+++ b/packages/werkzeug/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "werkzeug_placeholder_wrapper"
-version = "0.0.1"
+version = "0.0.2"

--- a/release/pipeline.yaml
+++ b/release/pipeline.yaml
@@ -191,31 +191,6 @@ spec:
       runAfter:
         - reduce-snapshot
 
-    - name: extract-binaries-from-image
-      taskRef:
-        resolver: "git"
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/release-service-catalog.git
-          - name: revision
-            value: production
-          - name: pathInRepo
-            value: tasks/managed/extract-binaries-from-image/extract-binaries-from-image.yaml
-      params:
-        - name: subdirectory
-          value: $(context.pipelineRun.uid)
-        - name: snapshotPath
-          value: "$(tasks.collect-data.results.snapshotSpec)"
-        - name: taskGitUrl
-          value: "https://github.com/konflux-ci/release-service-catalog.git"
-        - name: taskGitRevision
-          value: "production"
-      workspaces:
-        - name: data
-          workspace: release-workspace
-      runAfter:
-        - verify-enterprise-contract
-
     - name: push-py-pulp
       taskRef:
         resolver: "git"
@@ -227,10 +202,8 @@ spec:
           - name: pathInRepo
             value: release/push-py-pulp-task.yaml
       params:
-        - name: IMAGES
+        - name: SNAPSHOT_PATH
           value: "$(workspaces.data.path)/$(tasks.collect-data.results.snapshotSpec)"
-        - name: SUBDIRECTORY
-          value: $(tasks.extract-binaries-from-image.results.binaries_path)
         - name: PULP_BASE_URL
           value: $(params.pulpBaseUrl)
         - name: PULP_API_ROOT
@@ -246,7 +219,6 @@ spec:
           workspace: release-workspace
       runAfter:
         - verify-enterprise-contract
-        - extract-binaries-from-image
 
     # TODO: Consider re-enabling this.
     # - name: update-cr-status

--- a/release/push-py-pulp-task.yaml
+++ b/release/push-py-pulp-task.yaml
@@ -4,15 +4,11 @@ metadata:
   name: push-py-pulp
 spec:
   description: |
-    A task to push Python packages to a Pulp repository.
-    Currently just a placeholder that prints hello world.
+    A task to push Python packages from an OCI artifact to a Pulp repository.
   params:
-    - name: IMAGES
+    - name: SNAPSHOT_PATH
       type: string
       description: Path to the snapshot spec file containing image information
-    - name: SUBDIRECTORY
-      type: string
-      description: The subdirectory to use for the workspace
     - name: PULP_SECRET_NAME
       type: string
       description: >-
@@ -38,11 +34,12 @@ spec:
     - name: pulp-secret
       secret:
         secretName: $(params.PULP_SECRET_NAME)
+    - name: workdir
+      emptyDir: {}
   stepTemplate:
-    workingDir: "$(workspaces.data.path)/$(params.SUBDIRECTORY)"
     env:
-      - name: IMAGES
-        value: $(params.IMAGES)
+      - name: SNAPSHOT_PATH
+        value: $(params.SNAPSHOT_PATH)
       - name: PULP_BASE_URL
         value: $(params.PULP_BASE_URL)
       - name: PULP_API_ROOT
@@ -51,23 +48,51 @@ spec:
         value: $(params.PULP_DOMAIN)
       - name: PULP_REPOSITORY
         value: $(params.PULP_REPOSITORY)
+      - name: IMAGES_TXT
+        value: $(params.SNAPSHOT_PATH)/images.txt
+      - name: FILES_DIR
+        value: $(params.SNAPSHOT_PATH)/files
+    volumeMounts:
+      - name: pulp-secret
+        mountPath: "/etc/pulp-secret"
+        readOnly: true
+      - name: workdir
+        mountPath: "/var/workdir"
+    workingDir: "/var/workdir"
   steps:
+    - name: get-image-urls
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        < "${SNAPSHOT_PATH}" jq -r '.components[].containerImage' | tee "${IMAGES_TXT}"
+
+    - name: extract-artifacts
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        AUTHFILE='/tmp/auth.json'
+        select-oci-auth "$IMAGE" > "${AUTHFILE}"
+
+        mkdir -p "${FILES_DIR}"
+        pushd "${FILES_DIR}" > /dev/null
+        < "${IMAGES_TXT}" xargs -L 1 retry oras pull --registry-config "${AUTHFILE}"
+        popd > /dev/null
+
+        ls -la "${FILES_DIR}"
+
     - name: upload
       image: quay.io/lucarval/calunga-builder:latest
       # TODO: Remove this after a proper image is used. The image should be pinned.
       imagePullPolicy: Always
-      volumeMounts:
-        - name: pulp-secret
-          mountPath: "/etc/pulp-secret"
-          readOnly: true
       script: |
         #!/usr/bin/env bash
-        echo "Hello World from push-py-pulp task!"
-        echo "Workspace contents:"
-        ls -la .
-        pwd
 
-        ls -la /etc/pulp-secret
+        cd "${FILES_DIR}"
+        ls -la .
 
         pulp --help
 

--- a/release/push-py-pulp-task.yaml
+++ b/release/push-py-pulp-task.yaml
@@ -49,9 +49,9 @@ spec:
       - name: PULP_REPOSITORY
         value: $(params.PULP_REPOSITORY)
       - name: IMAGES_TXT
-        value: $(params.SNAPSHOT_PATH)/images.txt
+        value: $(workspaces.data.path)/images.txt
       - name: FILES_DIR
-        value: $(params.SNAPSHOT_PATH)/files
+        value: $(workspaces.data.path)/files
     volumeMounts:
       - name: pulp-secret
         mountPath: "/etc/pulp-secret"
@@ -75,12 +75,12 @@ spec:
         set -euo pipefail
 
         AUTHFILE='/tmp/auth.json'
-        select-oci-auth "$IMAGE" > "${AUTHFILE}"
-
         mkdir -p "${FILES_DIR}"
-        pushd "${FILES_DIR}" > /dev/null
-        < "${IMAGES_TXT}" xargs -L 1 retry oras pull --registry-config "${AUTHFILE}"
-        popd > /dev/null
+        while read -r IMAGE; do
+          echo "Processing ${IMAGE}"
+          select-oci-auth "${IMAGE}" > "${AUTHFILE}"
+          retry oras pull --registry-config "${AUTHFILE}" "${IMAGE}" -o "${FILES_DIR}"
+        done < "${IMAGES_TXT}"
 
         ls -la "${FILES_DIR}"
 

--- a/src/calunga/commands/generate.py
+++ b/src/calunga/commands/generate.py
@@ -157,15 +157,9 @@ version = "0.0.1"
             base_path
         )
 
-    # Generate argfile.conf
+    # TODO: argfile.conf is no longer needed. Eventually, we should remove it but to avoid an
+    # avalanche of builds, we'll just ignore it for now.
     argfile_path = path / "argfile.conf"
-    if not argfile_path.exists():
-        package_config = additional_requirements.get("packages", {}).get(name, {})
-        package_name = package_config.get("package_name", name.replace("-", "_"))
-
-        argfile_content = f"PACKAGE_NAME={package_name}\n"
-        with open(argfile_path, "w") as f:
-            f.write(argfile_content)
 
 
 def generate_konflux_resources(name: str, base_path: Path) -> None:

--- a/src/calunga/commands/generate.py
+++ b/src/calunga/commands/generate.py
@@ -215,9 +215,13 @@ spec:
         f.write(set_package_name_content)
 
 
-def generate_pac_resources(name: str, path: Path, base_path: Path) -> None:
+def generate_pac_resources(name: str, path: Path, base_path: Path, additional_requirements: Dict[str, Any]) -> None:
     """Generate Pipeline as Code resources."""
     console.print(f"  [blue]Generating Pipeline as Code resources for {name}[/blue]")
+
+
+    package_config = additional_requirements.get("packages", {}).get(name, {})
+    package_name = package_config.get("package_name", name.replace("-", "_"))
 
     # Determine containerfile
     containerfile = "Containerfile"
@@ -241,6 +245,7 @@ def generate_pac_resources(name: str, path: Path, base_path: Path) -> None:
 
             # Simple variable substitution
             substituted_content = template_content.replace("${name}", name)
+            substituted_content = substituted_content.replace("${package_name}", package_name)
             substituted_content = substituted_content.replace("${containerfile}", containerfile)
 
             # Append to output file
@@ -338,7 +343,7 @@ def generate(
                 console.print("  [dim]Skipping Konflux resource generation[/dim]")
 
             if not skip_pac:
-                generate_pac_resources(name, package_path, base_path)
+                generate_pac_resources(name, package_path, base_path, additional_requirements)
             else:
                 console.print("  [dim]Skipping Pipeline as Code generation[/dim]")
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -168,7 +168,6 @@ def test_generate_package_wrapper(temp_workspace):
     # Check that files were created
     assert (pkg_path / "pyproject.toml").exists()
     assert (pkg_path / "requirements.in").exists()
-    assert (pkg_path / "argfile.conf").exists()
 
     # Check pyproject.toml content
     with open(pkg_path / "pyproject.toml") as f:
@@ -180,11 +179,6 @@ def test_generate_package_wrapper(temp_workspace):
         content = f.read()
         assert "test-pkg-1" in content
         assert "setuptools" in content
-
-    # Check argfile.conf content
-    with open(pkg_path / "argfile.conf") as f:
-        content = f.read()
-        assert "PACKAGE_NAME=test_pkg_1" in content
 
 
 def test_generate_package_wrapper_skip_existing(temp_workspace):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new build task for creating and pushing arbitrary files as OCI artifacts.
  * Simplified the build pipeline to focus on building Python wheels with fewer steps and parameters.
  * Added support for specifying package names in pipeline run templates and additional requirements.

* **Bug Fixes**
  * Updated release tasks to pull and upload Python packages from OCI artifacts, replacing placeholder logic.

* **Chores**
  * Removed unused or unnecessary parameters and fields from pipeline and run templates.
  * Disabled generation and testing of the obsolete `argfile.conf` file.
  * Changed rebuild marker file from `argfile.conf` to `pyproject.toml`.
  * Incremented the version of the "werkzeug_placeholder_wrapper" package to 0.0.2.
  * Added package entry for `markdown-it-py` with specified package name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->